### PR TITLE
Implement 2025/2026 Per-Cultivation Nitrogen Norm Aggregation

### DIFF
--- a/.changeset/fdm-app-norms-explanation.md
+++ b/.changeset/fdm-app-norms-explanation.md
@@ -1,0 +1,9 @@
+---
+"@nmi-agro/fdm-app": minor
+---
+
+Improve gebruiksruimte UI with field-level norm explanations and non-supported edge cases context:
+
+- Display per-norm calculation descriptions and footnote breakdowns (`normSource`) on the individual field norms page (`NormCard`).
+- Display application amounts with their display unit (`p_app_amount_display` and `p_app_amount_unit`) on the individual field norms page.
+- Move the gebruiksruimte disclaimer and edge-cases explanation component (`NormsDisclaimer`) into `FarmTitle` with a quieter inline design and collapsible details for non-supported Meststoffenwet provisions.

--- a/.changeset/long-cities-behave.md
+++ b/.changeset/long-cities-behave.md
@@ -1,0 +1,11 @@
+---
+"@nmi-agro/fdm-docs": minor
+---
+
+Update 2025 and 2026 Dutch nitrogen usage norm (`stikstofgebruiksruimte`) documentation:
+
+- Document per-teelt accumulation and volgteelt rules per RVO Tabel 2.
+- Document footnote 7a/7b green manure conditions and footnote 2/6 maize exclusions.
+- Document hoofdgewas definition (longest presence in 15 May – 15 July window).
+- Document intentional crop code mappings (quinoa to spinach volgteelt, grass catch crops to grass seed rows, nature/fallow to 0 kg N/ha).
+- Add explicit out-of-scope / not-yet-implemented section covering yield-based norm increases (stikstofdifferentiatie / art. 28c Urm Tabel 1a), French-fry potatoes on clay (Tabel 2a), grass seed with fodder cut, mixed cropping/undersowing, fixed farm norm (footnote 9), and two-year winter crop budget splits (footnote 5/18).

--- a/.changeset/long-cities-behave.md
+++ b/.changeset/long-cities-behave.md
@@ -5,7 +5,7 @@
 Update 2025 and 2026 Dutch nitrogen usage norm (`stikstofgebruiksruimte`) documentation:
 
 - Document per-teelt accumulation and volgteelt rules per RVO Tabel 2.
-- Document footnote 7a/7b green manure conditions and footnote 2/6 maize exclusions.
+- Document footnote 7a green manure conditions and footnote 2/6 maize exclusions.
 - Document hoofdgewas definition (longest presence in 15 May – 15 July window).
 - Document intentional crop code mappings (quinoa to spinach volgteelt, grass catch crops to grass seed rows, nature/fallow to 0 kg N/ha).
-- Add explicit out-of-scope / not-yet-implemented section covering yield-based norm increases (stikstofdifferentiatie / art. 28c Urm Tabel 1a), French-fry potatoes on clay (Tabel 2a), grass seed with fodder cut, mixed cropping/undersowing, fixed farm norm (footnote 9), and two-year winter crop budget splits (footnote 5/18).
+- Add explicit out-of-scope / not-yet-implemented section covering yield-based norm increases (stikstofdifferentiatie / art. 28c Urm Tabel 1a), French-fry potatoes on clay (Tabel 2a), grass seed with fodder cut, grass seed stubble destruction (footnote 7b), mixed cropping/undersowing, fixed farm norm (footnote 9), and two-year winter crop budget splits (footnote 5/18).

--- a/.changeset/odd-suits-laugh.md
+++ b/.changeset/odd-suits-laugh.md
@@ -1,0 +1,15 @@
+---
+"@nmi-agro/fdm-calculator": minor
+---
+
+Implement per-teelt nitrogen usage norm (`stikstofgebruiksnorm`) accumulation and full Meststoffenwet compliance for norm years 2025 and 2026:
+
+- Per-teelt accumulation: Iterate over all crops grown in a calendar year and sum their nitrogen usage norms per RVO Tabel 2, instead of calculating exclusively for the hoofdteelt.
+- Volgteelt differentiation: Select volgteelt sub-types and standard rows for successor crops (e.g. spinach, lettuce varieties, endive, and grass seed volgteelt rows).
+- Green manure conditions (footnote 7a & 7b): Enforce statutory sowing (before 1 September) and standing duration (until at least 1 February of the following year), valid preceding crops (granen, koolzaad, graszaad for 100% norm; 50% on sand/loess after temporary grassland), and graszaadstoppel conditions.
+- Exclusion after maize (footnotes 2 & 6): Automatically suppress norms (0 kg N/ha) for green manures, temporary grassland, and catch crops following maize.
+- Grassland renewal korting (footnote 14): Align renewal window to 1 June – 31 August (on clay/peat in 2025: only for derogation permit holders).
+- Grassland destruction korting (footnotes 15 & 16): Backport catch-crop-grass exclusion to 2025 and withhold korting instead of throwing errors when destruction occurs outside allowed statutory windows.
+- Data corrections: Correct Veldbeemdgras standard norms on sand (100 kg N/ha on zand_nwc, 80 kg N/ha on zand_zuid), fix typos, and map nature/non-agricultural codes (`nl_332`, `nl_335`) to `Geen plaatsingsruimte` (0 kg N/ha).
+- Detailed norm source: Output informative `normSource` string detailing per-teelt breakdowns and explicit reasons when footnote conditions or exemptions apply.
+

--- a/.changeset/odd-suits-laugh.md
+++ b/.changeset/odd-suits-laugh.md
@@ -6,10 +6,9 @@ Implement per-teelt nitrogen usage norm (`stikstofgebruiksnorm`) accumulation an
 
 - Per-teelt accumulation: Iterate over all crops grown in a calendar year and sum their nitrogen usage norms per RVO Tabel 2, instead of calculating exclusively for the hoofdteelt.
 - Volgteelt differentiation: Select volgteelt sub-types and standard rows for successor crops (e.g. spinach, lettuce varieties, endive, and grass seed volgteelt rows).
-- Green manure conditions (footnote 7a & 7b): Enforce statutory sowing (before 1 September) and standing duration (until at least 1 February of the following year), valid preceding crops (granen, koolzaad, graszaad for 100% norm; 50% on sand/loess after temporary grassland), and graszaadstoppel conditions.
-- Exclusion after maize (footnotes 2 & 6): Automatically suppress norms (0 kg N/ha) for green manures, temporary grassland, and catch crops following maize.
-- Grassland renewal korting (footnote 14): Align renewal window to 1 June – 31 August (on clay/peat in 2025: only for derogation permit holders).
-- Grassland destruction korting (footnotes 15 & 16): Backport catch-crop-grass exclusion to 2025 and withhold korting instead of throwing errors when destruction occurs outside allowed statutory windows.
+- Green manure conditions (footnote 7a & 7b): Enforce statutory sowing (strictly before 1 September) and standing duration (until at least 1 February of the following year), valid preceding crops (granen, koolzaad, graszaad for 100% norm; 50% on sand/loess after temporary grassland), and graszaadstoppel conditions.
+- Exclusion after maize (footnotes 2 & 6): Automatically suppress norms (0 kg N/ha) for green manures, temporary grassland, and catch crops immediately following maize.
+- Grassland renewal korting (footnote 14): Align renewal window to 1 June – 31 August (on clay/peat in 2025: only for derogation permit holders; on all soil types in 2026).
+- Grassland destruction korting (footnotes 15 & 16): Gate 2025 destruction korting on clay/peat to derogation permit holders, backport catch-crop-grass exclusion to 2025, and withhold korting instead of throwing errors when destruction occurs outside allowed statutory windows.
 - Data corrections: Correct Veldbeemdgras standard norms on sand (100 kg N/ha on zand_nwc, 80 kg N/ha on zand_zuid), fix typos, and map nature/non-agricultural codes (`nl_332`, `nl_335`) to `Geen plaatsingsruimte` (0 kg N/ha).
 - Detailed norm source: Output informative `normSource` string detailing per-teelt breakdowns and explicit reasons when footnote conditions or exemptions apply.
-

--- a/.changeset/odd-suits-laugh.md
+++ b/.changeset/odd-suits-laugh.md
@@ -2,11 +2,11 @@
 "@nmi-agro/fdm-calculator": minor
 ---
 
-Implement per-teelt nitrogen usage norm (`stikstofgebruiksnorm`) accumulation and full Meststoffenwet compliance for norm years 2025 and 2026:
+Implement per-teelt nitrogen usage norm (`stikstofgebruiksnorm`) accumulation for norm years 2025 and 2026:
 
 - Per-teelt accumulation: Iterate over all crops grown in a calendar year and sum their nitrogen usage norms per RVO Tabel 2, instead of calculating exclusively for the hoofdteelt.
 - Volgteelt differentiation: Select volgteelt sub-types and standard rows for successor crops (e.g. spinach, lettuce varieties, endive, and grass seed volgteelt rows).
-- Green manure conditions (footnote 7a & 7b): Enforce statutory sowing (strictly before 1 September) and standing duration (until at least 1 February of the following year), valid preceding crops (granen, koolzaad, graszaad for 100% norm; 50% on sand/loess after temporary grassland), and graszaadstoppel conditions.
+- Green manure conditions (footnote 7a): Enforce statutory sowing (strictly before 1 September) and standing duration (until at least 1 February of the following year), and valid preceding crops (granen, koolzaad, graszaad for 100% norm; 50% on sand/loess after temporary grassland).
 - Exclusion after maize (footnotes 2 & 6): Automatically suppress norms (0 kg N/ha) for green manures, temporary grassland, and catch crops immediately following maize.
 - Grassland renewal korting (footnote 14): Align renewal window to 1 June – 31 August (on clay/peat in 2025: only for derogation permit holders; on all soil types in 2026).
 - Grassland destruction korting (footnotes 15 & 16): Gate 2025 destruction korting on clay/peat to derogation permit holders, backport catch-crop-grass exclusion to 2025, and withhold korting instead of throwing errors when destruction occurs outside allowed statutory windows.

--- a/fdm-app/app/components/blocks/farm/farm-title.tsx
+++ b/fdm-app/app/components/blocks/farm/farm-title.tsx
@@ -15,6 +15,7 @@ interface FarmTitleProps {
     to: string
     label: string
   }
+  children?: ReactNode
 }
 
 export function FarmTitle({
@@ -23,6 +24,7 @@ export function FarmTitle({
   descriptionNode,
   rightNode,
   action,
+  children,
 }: FarmTitleProps) {
   return (
     <div className="space-y-6 p-4 pb-0 md:px-8 md:py-8">
@@ -46,6 +48,7 @@ export function FarmTitle({
           )}
         </div>
       </div>
+      {children}
       <Separator className="my-6" />
     </div>
   )

--- a/fdm-app/app/components/blocks/norms/norm-card.tsx
+++ b/fdm-app/app/components/blocks/norms/norm-card.tsx
@@ -6,43 +6,49 @@ interface NormCardProps {
   norm: number
   filling: number | undefined
   unit: string
+  description?: string
 }
 
-export function NormCard({ title, norm, filling, unit }: NormCardProps) {
+export function NormCard({ title, norm, filling, unit, description }: NormCardProps) {
   const fillingpercentage = filling || 0
   const { percentage } = computeNormProgress(fillingpercentage, norm)
 
   return (
-    <Card>
-      <CardHeader className="pb-4">
-        <CardTitle className="text-base font-medium">{title}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="flex items-baseline justify-between">
+    <Card className="flex flex-col justify-between">
+      <div>
+        <CardHeader className="pb-4">
+          <CardTitle className="text-base font-medium">{title}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-baseline justify-between">
+            {filling !== undefined && (
+              <div className="text-left">
+                <p className="text-muted-foreground text-xs">Opvulling</p>
+                <div className="text-3xl font-semibold">{fillingpercentage.toFixed(0)}</div>
+              </div>
+            )}
+            <div className="text-right">
+              <p className="text-muted-foreground text-xs">Ruimte</p>
+              <div className="text-3xl font-bold">{norm.toFixed(0)}</div>
+              <p className="text-muted-foreground text-sm">{unit}</p>
+            </div>
+          </div>
           {filling !== undefined && (
-            <div className="text-left">
-              <p className="text-muted-foreground text-xs">Opvulling</p>
-              <div className="text-3xl font-semibold">{fillingpercentage.toFixed(0)}</div>
-              {/* <p className="text-sm text-muted-foreground">
-                                {unit}
-                            </p> */}
+            <div className="mt-4">
+              <NormProgressBar used={fillingpercentage} limit={norm} />
+              <p className="text-muted-foreground mt-1 text-right text-sm">
+                {percentage.toFixed(0)}%
+              </p>
             </div>
           )}
-          <div className="text-right">
-            <p className="text-muted-foreground text-xs">Ruimte</p>
-            <div className="text-3xl font-bold">{norm.toFixed(0)}</div>
-            <p className="text-muted-foreground text-sm">{unit}</p>
-          </div>
+        </CardContent>
+      </div>
+      {description && (
+        <div className="border-border/60 bg-muted/30 rounded-b-xl border-t px-6 py-3">
+          <p className="text-muted-foreground mb-0.5 text-xs font-medium">Toelichting norm</p>
+          <p className="text-foreground/80 text-xs leading-relaxed break-words">{description}</p>
         </div>
-        {filling !== undefined && (
-          <div className="mt-4">
-            <NormProgressBar used={fillingpercentage} limit={norm} />
-            <p className="text-muted-foreground mt-1 text-right text-sm">
-              {percentage.toFixed(0)}%
-            </p>
-          </div>
-        )}
-      </CardContent>
+      )}
     </Card>
   )
 }

--- a/fdm-app/app/components/blocks/norms/norms-disclaimer.tsx
+++ b/fdm-app/app/components/blocks/norms/norms-disclaimer.tsx
@@ -1,0 +1,97 @@
+import { ChevronDown, ChevronUp, Info } from "lucide-react"
+import { useState } from "react"
+import { Button } from "~/components/ui/button"
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "~/components/ui/collapsible"
+import { cn } from "~/lib/utils"
+
+interface NormsDisclaimerProps {
+  calendar?: string
+  className?: string
+}
+
+export function NormsDisclaimer({ className }: NormsDisclaimerProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div
+      className={cn(
+        "border-border/60 bg-muted/40 text-muted-foreground rounded-lg border p-3.5 text-xs transition-colors sm:p-4",
+        className,
+      )}
+    >
+      <div className="flex items-start gap-2.5">
+        <Info className="text-muted-foreground/80 mt-0.5 h-4 w-4 shrink-0" />
+        <div className="flex-1 space-y-2">
+          <p className="leading-relaxed">
+            De getoonde gebruiksnormen zijn indicatief en uitsluitend bedoeld voor informatieve
+            doeleinden. Raadpleeg altijd de officiële RVO-publicaties en uw adviseur voor
+            definitieve normen en juridische naleving.
+          </p>
+
+          <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+            <div className="flex items-center">
+              <CollapsibleTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-foreground/80 hover:bg-muted/80 hover:text-foreground -ml-1.5 h-6 px-1.5 text-xs font-medium"
+                >
+                  <span>Niet-ondersteunde situaties</span>
+                  {isOpen ? (
+                    <ChevronUp className="ml-1 h-3 w-3 opacity-70" />
+                  ) : (
+                    <ChevronDown className="ml-1 h-3 w-3 opacity-70" />
+                  )}
+                </Button>
+              </CollapsibleTrigger>
+            </div>
+
+            <CollapsibleContent className="pt-2.5">
+              <div className="border-border/50 bg-background/60 text-muted-foreground rounded-md border p-3 text-xs leading-relaxed">
+                <p className="text-foreground mb-2 font-medium">
+                  Hoewel we proberen de gebruiksruimte zo nauwkeurig mogelijk te berekenen, zijn er
+                  situaties waarin dit (nog) niet kan of gebeurt, zoals:
+                </p>
+                <ul className="list-disc space-y-1.5 pl-4">
+                  <li>
+                    <span className="text-foreground font-medium">
+                      Opbrengstafhankelijke stikstofdifferentiatie:
+                    </span>{" "}
+                    Gebruiksruimteverhoging op basis van bewezen meerjarige gewasopbrengsten.
+                  </li>
+                  <li>
+                    <span className="text-foreground font-medium">Fritesaardappelen op klei:</span>{" "}
+                    Differentiatienormen voor geregistreerde fritesteelten.
+                  </li>
+                  <li>
+                    <span className="text-foreground font-medium">
+                      Graszaad met voedersnede & stoppelvernietiging:
+                    </span>{" "}
+                    Vereist specifieke teeltgegevens (min. 8–10 weken standtijd, ploegen na 1
+                    december) die nog niet worden opgeslagen in de applicatie.
+                  </li>
+                  <li>
+                    <span className="text-foreground font-medium">Mengteelten:</span> Gecombineerde
+                    teelten op hetzelfde perceel.
+                  </li>
+                  <li>
+                    <span className="text-foreground font-medium">
+                      Forfaitaire bedrijfsnorm (voetnoot 9):
+                    </span>{" "}
+                    Vaste 110 kg N/ha normregeling bij gemiddelden tussen 100 en 110 kg N/ha.
+                  </li>
+                  <li>
+                    <span className="text-foreground font-medium">
+                      Tweejarige winterteelt budgetsplitsing (voetnoot 5/18):
+                    </span>{" "}
+                    Uitsplitsing van de stikstofruimte over zaai- en oogstjaar.
+                  </li>
+                </ul>
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.norms.$b_id.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.norms.$b_id.tsx
@@ -19,6 +19,7 @@ import { Header } from "~/components/blocks/header/base"
 import { HeaderFarm } from "~/components/blocks/header/farm"
 import { HeaderNorms } from "~/components/blocks/header/norms"
 import { NormCard } from "~/components/blocks/norms/norm-card"
+import { NormsDisclaimer } from "~/components/blocks/norms/norms-disclaimer"
 import { NormsFallback } from "~/components/blocks/norms/skeletons"
 import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card"
@@ -247,7 +248,9 @@ export default function FieldNormsBlock() {
         <FarmTitle
           title={"Gebruiksruimte"}
           description={`Bekijk de gebruiksruimte en opvulling voor ${loaderData.field.b_name}.`}
-        />
+        >
+          <NormsDisclaimer calendar={loaderData.calendar} />
+        </FarmTitle>
         <Suspense key={`${loaderData.b_id}#${loaderData.calendar}`} fallback={<NormsFallback />}>
           <FieldNormsContent {...loaderData} />
         </Suspense>
@@ -316,6 +319,13 @@ const FertilizerApplicationCard = ({
     )
   }
 
+  const formattedAmount =
+    application.p_app_amount_display !== null && application.p_app_amount_display !== undefined
+      ? `${application.p_app_amount_display} ${application.p_app_amount_unit}`
+      : application.p_app_amount !== null && application.p_app_amount !== undefined
+        ? `${application.p_app_amount} kg/ha`
+        : "Onbekende hoeveelheid"
+
   return (
     <Card>
       <CardHeader>
@@ -324,7 +334,7 @@ const FertilizerApplicationCard = ({
           {format(new Date(application.p_app_date), "d MMMM yyyy", {
             locale: nl,
           })}{" "}
-          - {application.p_app_amount} kg/ha
+          - {formattedAmount}
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -426,36 +436,32 @@ function FieldNormsContent(loaderData: Awaited<ReturnType<typeof loader>>) {
   return (
     <FarmContent>
       <div className="space-y-6 pb-10">
-        <Alert className="mb-8 border-amber-200 bg-amber-50 text-amber-800" variant="default">
-          <AlertTriangle className="h-4 w-4 !text-amber-800" />
-          <AlertTitle>Disclaimer</AlertTitle>
-          <AlertDescription>
-            Deze getallen zijn uitsluitend bedoeld voor informatieve doeleinden. De getoonde
-            gebruiksnormen zijn indicatief en dienen te worden geverifieerd voor juridische
-            naleving. Raadpleeg altijd de officiële RVO-publicaties en uw adviseur voor definitieve
-            normen.
-          </AlertDescription>
-        </Alert>
-
         <div>
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+          <div
+            className={`grid grid-cols-1 gap-6 md:grid-cols-2 ${
+              showRenure ? "lg:grid-cols-4" : "lg:grid-cols-3"
+            }`}
+          >
             <NormCard
               title="Stikstof, werkzaam"
               norm={norms?.nitrogen.normValue ?? 0}
               filling={normsFilling?.nitrogen.normFilling}
               unit="kg N"
+              description={norms?.nitrogen.normSource}
             />
             <NormCard
               title="Fosfaat"
               norm={norms?.phosphate.normValue ?? 0}
               filling={normsFilling?.phosphate.normFilling}
               unit="kg P₂O₅"
+              description={norms?.phosphate.normSource}
             />
             <NormCard
               title="Stikstof uit dierlijke mest"
               norm={norms?.manure.normValue ?? 0}
               filling={normsFilling?.manure.normFilling}
               unit="kg N"
+              description={norms?.manure.normSource}
             />
             {showRenure && (
               <NormCard
@@ -463,6 +469,7 @@ function FieldNormsContent(loaderData: Awaited<ReturnType<typeof loader>>) {
                 norm={norms?.renure?.normValue ?? 0}
                 filling={normsFilling?.renure?.normFilling}
                 unit="kg N"
+                description={norms?.renure?.normSource}
               />
             )}
           </div>

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.norms._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.norms._index.tsx
@@ -12,7 +12,6 @@ import {
   NormNotApplicableError,
 } from "@nmi-agro/fdm-calculator"
 import { getFarm, getFarms, getFields } from "@nmi-agro/fdm-core"
-import { AlertTriangle } from "lucide-react"
 import { Suspense, use, useEffect } from "react"
 import {
   data,
@@ -29,8 +28,8 @@ import { HeaderFarm } from "~/components/blocks/header/farm"
 import { HeaderNorms } from "~/components/blocks/header/norms"
 import { FarmNorms } from "~/components/blocks/norms/farm-norms"
 import { FieldNorms } from "~/components/blocks/norms/field-norms"
+import { NormsDisclaimer } from "~/components/blocks/norms/norms-disclaimer"
 import { NormsFallback } from "~/components/blocks/norms/skeletons"
-import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert"
 import { Button } from "~/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card"
 import { Separator } from "~/components/ui/separator"
@@ -282,7 +281,9 @@ export default function FarmNormsBlock() {
         <FarmTitle
           title={"Gebruiksruimte"}
           description={"Bekijk de gebruiksruimte en opvulling voor je bedrijf en percelen."}
-        />
+        >
+          <NormsDisclaimer calendar={loaderData.calendar} />
+        </FarmTitle>
         <Suspense
           key={`${loaderData.b_id_farm}#${loaderData.calendar}`}
           fallback={<NormsFallback />}
@@ -368,17 +369,6 @@ function Norms(loaderData: Awaited<ReturnType<typeof loader>>) {
     return (
       <FarmContent>
         <div className="space-y-6 pb-10">
-          <Alert className="mb-8 border-amber-200 bg-amber-50 text-amber-800" variant="default">
-            <AlertTriangle className="h-4 w-4 !text-amber-800" />
-            <AlertTitle>Disclaimer</AlertTitle>
-            <AlertDescription>
-              Deze getallen zijn uitsluitend bedoeld voor informatieve doeleinden. De getoonde
-              gebruiksnormen zijn indicatief en dienen te worden geverifieerd voor juridische
-              naleving. Raadpleeg altijd de officiële RVO-publicaties en uw adviseur voor
-              definitieve normen.
-            </AlertDescription>
-          </Alert>
-
           <FarmNorms
             farmNorms={farmNorms}
             farmFillings={farmFillings}

--- a/fdm-calculator/src/index.ts
+++ b/fdm-calculator/src/index.ts
@@ -163,8 +163,5 @@ export type { NlvParams, NlvSupplyBySomParams } from "./other/nlv-supply"
 export { calculateNlv, calculateNlvSupplyIncreaseBySomPotential } from "./other/nlv-supply"
 export type { WaterSupplyBySomParams } from "./other/water-supply-by-som"
 export { calculateWaterSupplyBySom } from "./other/water-supply-by-som"
-export type {
-  CompleteHoofdteeltCultivation,
-  CultivationForHoofdteelt,
-} from "./shared/hoofdteelt"
+export type { CompleteHoofdteeltCultivation, CultivationForHoofdteelt } from "./shared/hoofdteelt"
 export { findHoofdteelt, GROENE_BRAAK } from "./shared/hoofdteelt"

--- a/fdm-calculator/src/norms/nl/2025/filling/stikstofgebruiksnorm.test.ts
+++ b/fdm-calculator/src/norms/nl/2025/filling/stikstofgebruiksnorm.test.ts
@@ -437,7 +437,14 @@ describe("getWorkingCoefficient", () => {
   })
 
   it("should return default details when no subtype matches an entry with subtypes", () => {
-    const result = getWorkingCoefficient("46", undefined, false, true, new Date("2025-06-15"), false)
+    const result = getWorkingCoefficient(
+      "46",
+      undefined,
+      false,
+      true,
+      new Date("2025-06-15"),
+      false,
+    )
     expect(result.p_n_wcl).toBe(1)
     expect(result.description).toBe("Kunstmest")
   })

--- a/fdm-calculator/src/norms/nl/2025/value/dierlijke-mest-gebruiksnorm.test.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/dierlijke-mest-gebruiksnorm.test.ts
@@ -205,8 +205,8 @@ describe("calculateNL2025DierlijkeMestGebruiksNorm", () => {
   it("should return false for unknown geotiff codes in GWBG and Natura helpers", async () => {
     const getUnknownGeoTiffValue = async () => 99
     await expect(isFieldInGWGBGebied([5.0, 52.0], getUnknownGeoTiffValue)).resolves.toBe(false)
-    await expect(
-      isFieldInNatura2000Gebied([5.0, 52.0], getUnknownGeoTiffValue),
-    ).resolves.toBe(false)
+    await expect(isFieldInNatura2000Gebied([5.0, 52.0], getUnknownGeoTiffValue)).resolves.toBe(
+      false,
+    )
   })
 })

--- a/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm-data.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm-data.ts
@@ -707,21 +707,21 @@ export const nitrogenStandardsData = [
     },
   },
   {
-    cultivation_rvo_table2: "Akkerbouwgewassen,Veldbeemdgras",
+    cultivation_rvo_table2: "Akkerbouwgewassen, Veldbeemdgras",
     b_lu_catalogue_match: ["nl_1916", "nl_3523", "nl_6746", "nl_6788", "nl_6789"],
     type: "graszaad",
     is_winterteelt: true,
     is_vanggewas: true,
     norms: {
       klei: { standard: 130, nv_area: 104 },
-      zand_nwc: { standard: 110, nv_area: 80 },
-      zand_zuid: { standard: 100, nv_area: 64 },
+      zand_nwc: { standard: 100, nv_area: 80 },
+      zand_zuid: { standard: 80, nv_area: 64 },
       loess: { standard: 80, nv_area: 64 },
       veen: { standard: 105, nv_area: 84 },
     },
   },
   {
-    cultivation_rvo_table2: "Akkerbouwgewassen,Veldbeemdgras, volgteelt",
+    cultivation_rvo_table2: "Akkerbouwgewassen, Veldbeemdgras, volgteelt",
     b_lu_catalogue_match: ["nl_1916", "nl_3523", "nl_6746", "nl_6788", "nl_6789"],
     type: "graszaad",
     is_winterteelt: true,
@@ -793,7 +793,7 @@ export const nitrogenStandardsData = [
     ],
   },
   {
-    cultivation_rvo_table2: "Akkerbouwgewassen, Graszaad,Westerwolds",
+    cultivation_rvo_table2: "Akkerbouwgewassen, Graszaad, Westerwolds",
     b_lu_catalogue_match: ["nl_1919", "nl_3513", "nl_6790", "nl_6791"],
     type: "graszaad",
     is_winterteelt: true,
@@ -1013,7 +1013,7 @@ export const nitrogenStandardsData = [
     ],
   },
   {
-    cultivation_rvo_table2: "Baldgewassen, Spinazie volgteelt",
+    cultivation_rvo_table2: "Bladgewassen, Spinazie volgteelt",
     b_lu_catalogue_match: ["nl_1022"],
     type: "bladgewas",
     is_winterteelt: true,
@@ -1367,7 +1367,7 @@ export const nitrogenStandardsData = [
     ],
   },
   {
-    cultivation_rvo_table2: "Kruiden, bladgewas, eemalige oogst",
+    cultivation_rvo_table2: "Kruiden, bladgewas, eenmalige oogst",
     b_lu_catalogue_match: [
       "nl_1019",
       "nl_1020",
@@ -2035,7 +2035,7 @@ export const nitrogenStandardsData = [
     },
   },
   {
-    cultivation_rvo_table2: "Bloembollengewassen,Lelie",
+    cultivation_rvo_table2: "Bloembollengewassen, Lelie",
     b_lu_catalogue_match: ["nl_979", "nl_980", "nl_1002"],
     type: "bloembol",
     is_winterteelt: true,
@@ -2348,7 +2348,7 @@ export const nitrogenStandardsData = [
     },
   },
   {
-    cultivation_rvo_table2: "Boomkwekerijgewassen,Sierheesters",
+    cultivation_rvo_table2: "Boomkwekerijgewassen, Sierheesters",
     b_lu_catalogue_match: ["nl_1075"],
     type: "boomkwekerij",
     is_winterteelt: true,
@@ -2446,7 +2446,7 @@ export const nitrogenStandardsData = [
     },
   },
   {
-    cultivation_rvo_table2: "Boomkwekerijgewassen, Vruchtbomen, overig,",
+    cultivation_rvo_table2: "Boomkwekerijgewassen, Vruchtbomen, overig",
     b_lu_catalogue_match: ["nl_1079"],
     type: "boomkwekerij",
     is_winterteelt: true,
@@ -2547,6 +2547,8 @@ export const nitrogenStandardsData = [
   {
     cultivation_rvo_table2: "Geen plaatsingsruimte",
     b_lu_catalogue_match: [
+      "nl_332",
+      "nl_335",
       "nl_338",
       "nl_1940",
       "nl_2300",

--- a/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.test.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.test.ts
@@ -851,17 +851,17 @@ describe("calculateNL2025StikstofGebruiksNorm - Korting Logic", () => {
         },
         field: {
           b_id: "1",
-          b_centroid: clayCentroid, // Assume Non-NV
+          b_centroid: clayCentroid, // Non-NV
         } as Field,
         cultivations: [
           {
             b_lu_catalogue: "nl_265", // Grass
             b_lu_start: new Date(2025, 0, 1),
-            b_lu_end: new Date(2025, 8, 1), // Sep 1
+            b_lu_end: new Date(2025, 7, 1), // Aug 1 (inside June 1 - Aug 31)
           },
           {
             b_lu_catalogue: "nl_265", // Grass
-            b_lu_start: new Date(2025, 8, 2),
+            b_lu_start: new Date(2025, 7, 2),
             b_lu_end: new Date(2025, 11, 31),
           },
         ] as NL2025NormsInputForCultivation[],
@@ -869,11 +869,10 @@ describe("calculateNL2025StikstofGebruiksNorm - Korting Logic", () => {
       }
 
       const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
-      // Derogation + Non-NV allows up to Sep 15. Sep 1 is valid.
       expect(result.normSource).toContain("Korting: 50kg N/ha: graslandvernieuwing")
     })
 
-    it("should throw error for invalid renewal date on Sand", async () => {
+    it("should not apply renewal discount for invalid renewal date on Sand", async () => {
       const mockInput: NL2025NormsInput = {
         farm: {
           is_derogatie_bedrijf: false,
@@ -887,7 +886,7 @@ describe("calculateNL2025StikstofGebruiksNorm - Korting Logic", () => {
           {
             b_lu_catalogue: "nl_265", // Grass
             b_lu_start: new Date(2025, 0, 1),
-            b_lu_end: new Date(2025, 4, 15), // May 15 (Too early)
+            b_lu_end: new Date(2025, 4, 15), // May 15 (Too early, outside June 1 - Aug 31)
           },
           {
             b_lu_catalogue: "nl_265", // Grass
@@ -898,9 +897,9 @@ describe("calculateNL2025StikstofGebruiksNorm - Korting Logic", () => {
         soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
       }
 
-      await expect(calculateNL2025StikstofGebruiksNorm(mockInput)).rejects.toThrow(
-        "Graslandvernieuwing op zand- en lössgrond is alleen toegestaan tussen 1 juni en 31 augustus.",
-      )
+      const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+      expect(result.normSource).not.toContain("graslandvernieuwing")
+      expect(result.normValue).toBe(256)
     })
   })
 
@@ -1156,7 +1155,7 @@ describe("calculateNL2025StikstofGebruiksNorm - Korting Logic", () => {
       expect(result.normSource).not.toContain("graslandvernietiging")
     })
 
-    it("should throw error for invalid destruction date on Sand", async () => {
+    it("should not apply destruction discount for invalid destruction date on Sand", async () => {
       const mockInput: NL2025NormsInput = {
         farm: {
           is_derogatie_bedrijf: false,
@@ -1181,9 +1180,9 @@ describe("calculateNL2025StikstofGebruiksNorm - Korting Logic", () => {
         soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
       }
 
-      await expect(calculateNL2025StikstofGebruiksNorm(mockInput)).rejects.toThrow(
-        "Graslandvernietiging op zand- en lössgrond is alleen toegestaan tussen 1 februari en 10 mei.",
-      )
+      const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+      expect(result.normSource).not.toContain("graslandvernietiging")
+      expect(result.normValue).toBe(368)
     })
   })
 })
@@ -1263,7 +1262,7 @@ describe("calculateNL2025StikstofGebruiksNorm - Additional Korting Edge Cases", 
     expect(result.normSource).toContain("Geen korting: vanggewas gezaaid uiterlijk 1 oktober")
   })
 
-  it("should apply 50 discount for Graslandvernieuwing on Clay (No Derogation) - Valid Date (Feb 10)", async () => {
+  it("should not apply 50 discount for Graslandvernieuwing on Clay (No Derogation) - Valid Date (Feb 10)", async () => {
     setupMock(1, 0) // Clay, Non-NV
     const mockInput: NL2025NormsInput = {
       farm: {
@@ -1290,10 +1289,10 @@ describe("calculateNL2025StikstofGebruiksNorm - Additional Korting Edge Cases", 
     }
 
     const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
-    expect(result.normSource).toContain("Korting: 50kg N/ha: graslandvernieuwing")
+    expect(result.normSource).not.toContain("graslandvernieuwing")
   })
 
-  it("should throw error for Graslandvernieuwing on Clay (No Derogation) - Invalid Date (Jan 20)", async () => {
+  it("should not apply discount or throw for Graslandvernieuwing on Clay (No Derogation) - Invalid Date (Jan 20)", async () => {
     setupMock(1, 0) // Clay, Non-NV
     const mockInput: NL2025NormsInput = {
       farm: {
@@ -1319,9 +1318,8 @@ describe("calculateNL2025StikstofGebruiksNorm - Additional Korting Edge Cases", 
       soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
     }
 
-    await expect(calculateNL2025StikstofGebruiksNorm(mockInput)).rejects.toThrow(
-      "Graslandvernieuwing op klei- en veengrond (geen derogatie) is alleen toegestaan tussen 1 februari en 15 september.",
-    )
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    expect(result.normSource).not.toContain("graslandvernieuwing")
   })
 
   it("should apply 50 discount for Graslandvernieuwing on Clay (Derogation + NV) - Valid Date (Aug 15)", async () => {
@@ -1354,7 +1352,7 @@ describe("calculateNL2025StikstofGebruiksNorm - Additional Korting Edge Cases", 
     expect(result.normSource).toContain("Korting: 50kg N/ha: graslandvernieuwing")
   })
 
-  it("should throw error for Graslandvernieuwing on Clay (Derogation + NV) - Invalid Date (Sep 10)", async () => {
+  it("should not apply discount or throw for Graslandvernieuwing on Clay (Derogation + NV) - Invalid Date (Sep 10)", async () => {
     setupMock(1, 1) // Clay, NV
     const mockInput: NL2025NormsInput = {
       farm: {
@@ -1380,9 +1378,8 @@ describe("calculateNL2025StikstofGebruiksNorm - Additional Korting Edge Cases", 
       soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
     }
 
-    await expect(calculateNL2025StikstofGebruiksNorm(mockInput)).rejects.toThrow(
-      "Graslandvernieuwing op klei- en veengrond (derogatie + NV-gebied) is alleen toegestaan tussen 1 juni en 31 augustus.",
-    )
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    expect(result.normSource).not.toContain("graslandvernieuwing")
   })
 
   it("should apply 65 discount for Graslandvernietiging on Clay (NV) - Valid Date (Mar 10)", async () => {
@@ -1415,7 +1412,7 @@ describe("calculateNL2025StikstofGebruiksNorm - Additional Korting Edge Cases", 
     expect(result.normSource).toContain("Korting: 65kg N/ha: graslandvernietiging")
   })
 
-  it("should throw error for Graslandvernietiging on Clay (NV) - Invalid Date (Mar 20)", async () => {
+  it("should not apply discount or throw for Graslandvernietiging on Clay (NV) - Invalid Date (Mar 20)", async () => {
     setupMock(1, 1) // Clay, NV
     const mockInput: NL2025NormsInput = {
       farm: {
@@ -1441,9 +1438,8 @@ describe("calculateNL2025StikstofGebruiksNorm - Additional Korting Edge Cases", 
       soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
     }
 
-    await expect(calculateNL2025StikstofGebruiksNorm(mockInput)).rejects.toThrow(
-      "Graslandvernietiging op klei- en veengrond (NV-gebied) is alleen toegestaan tussen 1 februari en 15 maart.",
-    )
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    expect(result.normSource).not.toContain("graslandvernietiging")
   })
 })
 
@@ -1877,7 +1873,9 @@ describe("NL2025 stikstof additional branch coverage", () => {
         } as NL2025NormsInputForCultivation,
       ]),
     )
-    expect(winterui.normSource).toBe("Akkerbouwgewassen, Ui overig, zaaiui of winterui. (1e jaars).")
+    expect(winterui.normSource).toBe(
+      "Akkerbouwgewassen, Ui overig, zaaiui of winterui. (1e jaars).",
+    )
     dataSpy.mockRestore()
   })
 
@@ -2009,11 +2007,11 @@ describe("NL2025 stikstof additional branch coverage", () => {
       ]),
     )
 
-    expect(result.normValue).toBe(180)
+    expect(result.normValue).toBe(540)
     dataSpy.mockRestore()
   })
 
-  it("throws for invalid clay renewal and destruction windows", async () => {
+  it("does not apply korting for invalid clay renewal and destruction windows", async () => {
     const dataSpy = spyNitrogenStandards([
       {
         b_lu_catalogue_match: ["nl_265"],
@@ -2031,43 +2029,41 @@ describe("NL2025 stikstof additional branch coverage", () => {
     ] as unknown as NitrogenStandard[])
 
     setupGeoMock(1, 0)
-    await expect(
-      calculateNL2025StikstofGebruiksNorm(
-        baseInput(
-          [
-            {
-              b_lu_catalogue: "nl_265",
-              b_lu_start: new Date(2025, 0, 1),
-              b_lu_end: new Date(2025, 9, 1),
-            } as NL2025NormsInputForCultivation,
-            {
-              b_lu_catalogue: "nl_265",
-              b_lu_start: new Date(2025, 9, 2),
-              b_lu_end: new Date(2025, 11, 31),
-            } as NL2025NormsInputForCultivation,
-          ],
-          { is_derogatie_bedrijf: true, has_grazing_intention: false },
-        ),
-      ),
-    ).rejects.toThrow("Graslandvernieuwing op klei- en veengrond (derogatie + niet NV-gebied)")
-
-    setupGeoMock(1, 1)
-    await expect(
-      calculateNL2025StikstofGebruiksNorm(
-        baseInput([
+    const renewalResult = await calculateNL2025StikstofGebruiksNorm(
+      baseInput(
+        [
           {
             b_lu_catalogue: "nl_265",
-            b_lu_start: new Date(2024, 0, 1),
-            b_lu_end: new Date(2025, 3, 20),
-          } as NL2025NormsInputForCultivation,
-          {
-            b_lu_catalogue: "nl_maize_invalid",
-            b_lu_start: new Date(2025, 4, 1),
+            b_lu_start: new Date(2025, 0, 1),
             b_lu_end: new Date(2025, 9, 1),
           } as NL2025NormsInputForCultivation,
-        ]),
+          {
+            b_lu_catalogue: "nl_265",
+            b_lu_start: new Date(2025, 9, 2),
+            b_lu_end: new Date(2025, 11, 31),
+          } as NL2025NormsInputForCultivation,
+        ],
+        { is_derogatie_bedrijf: true, has_grazing_intention: false },
       ),
-    ).rejects.toThrow("Graslandvernietiging op klei- en veengrond (NV-gebied)")
+    )
+    expect(renewalResult.normSource).not.toContain("graslandvernieuwing")
+
+    setupGeoMock(1, 1)
+    const destructionResult = await calculateNL2025StikstofGebruiksNorm(
+      baseInput([
+        {
+          b_lu_catalogue: "nl_265",
+          b_lu_start: new Date(2024, 0, 1),
+          b_lu_end: new Date(2025, 3, 20),
+        } as NL2025NormsInputForCultivation,
+        {
+          b_lu_catalogue: "nl_maize_invalid",
+          b_lu_start: new Date(2025, 4, 1),
+          b_lu_end: new Date(2025, 9, 1),
+        } as NL2025NormsInputForCultivation,
+      ]),
+    )
+    expect(destructionResult.normSource).not.toContain("graslandvernietiging")
 
     dataSpy.mockRestore()
   })
@@ -2150,21 +2146,284 @@ describe("NL2025 stikstof additional branch coverage", () => {
     ] as unknown as NitrogenStandard[])
 
     const result = await calculateNL2025StikstofGebruiksNorm(
-      baseInput([
-        {
-          b_lu_catalogue: "nl_265",
-          b_lu_start: new Date(2025, 0, 1),
-          b_lu_end: new Date(2025, 6, 1),
-        } as NL2025NormsInputForCultivation,
-        {
-          b_lu_catalogue: "nl_265",
-          b_lu_start: new Date(2025, 6, 2),
-          b_lu_end: new Date(2025, 11, 31),
-        } as NL2025NormsInputForCultivation,
-      ]),
+      baseInput(
+        [
+          {
+            b_lu_catalogue: "nl_265",
+            b_lu_start: new Date(2025, 0, 1),
+            b_lu_end: new Date(2025, 6, 1),
+          } as NL2025NormsInputForCultivation,
+          {
+            b_lu_catalogue: "nl_265",
+            b_lu_start: new Date(2025, 6, 2),
+            b_lu_end: new Date(2025, 11, 31),
+          } as NL2025NormsInputForCultivation,
+        ],
+        { is_derogatie_bedrijf: true, has_grazing_intention: false },
+      ),
     )
 
     expect(result.normSource).toContain("Korting: 50kg N/ha: graslandvernieuwing")
     dataSpy.mockRestore()
+  })
+})
+
+describe("calculateNL2025StikstofGebruiksNorm - Multi-Teelt & Compliance Tests", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const kleiCentroid: [number, number] = [5.64188724, 51.977587] // klei
+  const sandCentroid: [number, number] = [5.656346970245633, 51.987872886419524] // zand_nwc (NV)
+
+  it("should accumulate norms for wintertarwe + non-vlinderbloemige groenbemester (compliant dates)", async () => {
+    setupGeoMock(4, 1) // Sand, NV
+    const mockInput: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: sandCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_233", // Wintertarwe (160 standard / 128 NV on zand_nwc)
+          b_lu_start: new Date(2024, 9, 15), // Oct 15, 2024 (hoofdteelt 2025)
+          b_lu_end: new Date(2025, 7, 10), // Aug 10, 2025
+        },
+        {
+          b_lu_catalogue: "nl_428", // Groenbemester gele mosterd (50 standard / 40 NV on zand_nwc)
+          b_lu_start: new Date(2025, 7, 15), // Aug 15, 2025 (< Sep 1)
+          b_lu_end: new Date(2026, 1, 15), // Feb 15, 2026 (>= Feb 1)
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    // Wintertarwe: 128 (NV) + Groenbemester: 40 (NV) = 168 kg N/ha.
+    expect(result.normValue).toBe(168)
+    expect(result.normSource).toContain("Akkerbouwgewassen, wintertarwe (128 kg N/ha)")
+    expect(result.normSource).toContain(
+      "Groenbemesters, niet-vlinderbloemige (volgteelt na granen, graszaad of koolzaad, voetnoot 7a) (40 kg N/ha)",
+    )
+  })
+
+  it("should grant 0 norm for groenbemester if sown on or after 1 September (footnote 7a)", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_233", // Wintertarwe (245 on klei)
+          b_lu_start: new Date(2024, 9, 15),
+          b_lu_end: new Date(2025, 7, 10),
+        },
+        {
+          b_lu_catalogue: "nl_428", // Groenbemester
+          b_lu_start: new Date(2025, 8, 2), // Sep 2, 2025 (>= Sep 1 -> 0 norm)
+          b_lu_end: new Date(2026, 1, 15),
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    expect(result.normValue).toBe(245)
+    expect(result.normSource).toContain(
+      "Groenbemesters, niet-vlinderbloemige (geen norm: gezaaid op of na 1 september, voetnoot 7a) (0 kg N/ha)",
+    )
+  })
+
+  it("should grant 0 norm for groenbemester if destroyed before 1 February (footnote 7a)", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_233", // Wintertarwe (245 on klei)
+          b_lu_start: new Date(2024, 9, 15),
+          b_lu_end: new Date(2025, 7, 10),
+        },
+        {
+          b_lu_catalogue: "nl_428", // Groenbemester
+          b_lu_start: new Date(2025, 7, 15), // Aug 15
+          b_lu_end: new Date(2025, 11, 1), // Dec 1, 2025 (< Feb 1, 2026 -> 0 norm)
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    expect(result.normValue).toBe(245)
+    expect(result.normSource).toContain(
+      "Groenbemesters, niet-vlinderbloemige (geen norm: vernietigd vóór 1 februari, voetnoot 7a) (0 kg N/ha)",
+    )
+  })
+
+  it("should grant 50% groenbemester norm on sand after gras op bouwland (footnote 7a)", async () => {
+    setupGeoMock(4, 1) // Sand, NV
+    const mockInput: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: sandCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_266", // Tijdelijk grasland (van 1 jan tot minstens 15 aug -> 168 NV)
+          b_lu_start: new Date(2025, 0, 1),
+          b_lu_end: new Date(2025, 7, 15),
+        },
+        {
+          b_lu_catalogue: "nl_428", // Groenbemester
+          b_lu_start: new Date(2025, 7, 16), // Aug 16 (< Sep 1)
+          b_lu_end: new Date(2026, 1, 15),
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    // Tijdelijk grasland: 168 + Groenbemester 50% (40 * 0.5 = 20) = 188 kg N/ha
+    expect(result.normValue).toBe(188)
+    expect(result.normSource).toContain(
+      "Groenbemesters, niet-vlinderbloemige (50% norm na gras op bouwland, voetnoot 7a) (20 kg N/ha)",
+    )
+  })
+
+  it("should accumulate spinazie 1e teelt + spinazie volgteelt", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_2773", // Spinazie 1e teelt (260 on klei)
+          b_lu_start: new Date(2025, 3, 1), // April 1
+          b_lu_end: new Date(2025, 5, 15), // June 15 (hoofdteelt)
+        },
+        {
+          b_lu_catalogue: "nl_2773", // Spinazie volgteelt (185 on klei)
+          b_lu_start: new Date(2025, 6, 1), // July 1
+          b_lu_end: new Date(2025, 8, 15), // Sep 15
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    // 260 + 185 = 445 kg N/ha
+    expect(result.normValue).toBe(445)
+    expect(result.normSource).toContain("Bladgewassen, Spinazie (1e teelt) (260 kg N/ha)")
+    expect(result.normSource).toContain("Bladgewassen, Spinazie (volgteelt) (185 kg N/ha)")
+  })
+
+  it("should accumulate graszaad hoofdteelt + graszaad volgteelt", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_1915", // Rietzwenkgras (140 on klei)
+          b_lu_start: new Date(2025, 0, 1),
+          b_lu_end: new Date(2025, 6, 31),
+        },
+        {
+          b_lu_catalogue: "nl_1915", // Rietzwenkgras volgteelt (60 on klei)
+          b_lu_start: new Date(2025, 7, 1),
+          b_lu_end: new Date(2025, 11, 31),
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    // 140 + 60 = 200 kg N/ha
+    expect(result.normValue).toBe(200)
+    expect(result.normSource).toContain("Akkerbouwgewassen, Rietzwenkgras (140 kg N/ha)")
+    expect(result.normSource).toContain("Akkerbouwgewassen, Rietzwenkgras, volgteelt (60 kg N/ha)")
+  })
+
+  it("should grant 0 norm for groenbemester and tijdelijk grasland following maize (footnotes 2 & 6)", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_259", // Mais (185 on klei, geen derogatie)
+          b_lu_start: new Date(2025, 4, 1),
+          b_lu_end: new Date(2025, 8, 30),
+        },
+        {
+          b_lu_catalogue: "nl_428", // Groenbemester after maize
+          b_lu_start: new Date(2025, 9, 1),
+          b_lu_end: new Date(2026, 1, 15),
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    // Mais 185 + Groenbemester 0 = 185 kg N/ha
+    expect(result.normValue).toBe(185)
+    expect(result.normSource).toContain("Akkerbouwgewassen, mais (geen derogatie) (185 kg N/ha)")
+    expect(result.normSource).toContain(
+      "Groenbemesters, niet-vlinderbloemige (geen norm na maïs, voetnoot 2/6) (0 kg N/ha)",
+    )
+  })
+
+  it("should return norm 0 for groene braak (nl_6794) under Geen plaatsingsruimte", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_6794", // Groene braak
+          b_lu_start: new Date(2025, 4, 15),
+          b_lu_end: new Date(2025, 6, 15),
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    expect(result.normValue).toBe(0)
+    expect(result.normSource).toContain("Geen plaatsingsruimte")
+  })
+
+  it("should return norm 0 without throwing for nature codes nl_332 and nl_335", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput332: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_332", // natuurlijk grasland, hoofdfunctie natuur
+          b_lu_start: new Date(2025, 0, 1),
+          b_lu_end: new Date(2025, 11, 31),
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result332 = await calculateNL2025StikstofGebruiksNorm(mockInput332)
+    expect(result332.normValue).toBe(0)
+    expect(result332.normSource).toContain("Geen plaatsingsruimte")
+
+    const mockInput335: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_335", // natuurterreinen
+          b_lu_start: new Date(2025, 0, 1),
+          b_lu_end: new Date(2025, 11, 31),
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result335 = await calculateNL2025StikstofGebruiksNorm(mockInput335)
+    expect(result335.normValue).toBe(0)
+    expect(result335.normSource).toContain("Geen plaatsingsruimte")
   })
 })

--- a/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.test.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.test.ts
@@ -1095,7 +1095,37 @@ describe("calculateNL2025StikstofGebruiksNorm - Korting Logic", () => {
       expect(result.normSource).toContain("Korting: 65kg N/ha: graslandvernietiging")
     })
 
-    it("should apply 65 discount on Clay (Consumption Potato, Feb 1 - May 31)", async () => {
+    it("should apply 65 discount on Clay for derogation farm (Consumption Potato, Feb 1 - May 31)", async () => {
+      const mockInput: NL2025NormsInput = {
+        farm: {
+          is_derogatie_bedrijf: true,
+          has_grazing_intention: false,
+        },
+        field: {
+          b_id: "1",
+          b_centroid: clayCentroid,
+        } as Field,
+        cultivations: [
+          {
+            b_lu_catalogue: "nl_265", // Grass
+            b_lu_start: new Date(2025, 0, 1),
+            b_lu_end: new Date(2025, 3, 15), // April 15
+          },
+          {
+            b_lu_catalogue: "nl_2014", // Consumption Potato
+            b_lu_variety: "Agria", // Low norm
+            b_lu_start: new Date(2025, 3, 16),
+            b_lu_end: new Date(2025, 9, 1),
+          },
+        ] as NL2025NormsInputForCultivation[],
+        soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+      }
+
+      const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+      expect(result.normSource).toContain("Korting: 65kg N/ha: graslandvernietiging")
+    })
+
+    it("should NOT apply 65 destruction discount on Clay without derogation permit", async () => {
       const mockInput: NL2025NormsInput = {
         farm: {
           is_derogatie_bedrijf: false,
@@ -1122,7 +1152,7 @@ describe("calculateNL2025StikstofGebruiksNorm - Korting Logic", () => {
       }
 
       const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
-      expect(result.normSource).toContain("Korting: 65kg N/ha: graslandvernietiging")
+      expect(result.normSource).not.toContain("graslandvernietiging")
     })
 
     it("should NOT apply discount for Seed Potatoes", async () => {
@@ -1382,11 +1412,11 @@ describe("calculateNL2025StikstofGebruiksNorm - Additional Korting Edge Cases", 
     expect(result.normSource).not.toContain("graslandvernieuwing")
   })
 
-  it("should apply 65 discount for Graslandvernietiging on Clay (NV) - Valid Date (Mar 10)", async () => {
+  it("should apply 65 discount for Graslandvernietiging on Clay (NV) for derogation farm - Valid Date (Mar 10)", async () => {
     setupMock(1, 1) // Clay, NV
     const mockInput: NL2025NormsInput = {
       farm: {
-        is_derogatie_bedrijf: false,
+        is_derogatie_bedrijf: true,
         has_grazing_intention: false,
       },
       field: {
@@ -1921,7 +1951,7 @@ describe("NL2025 stikstof additional branch coverage", () => {
     dataSpy.mockRestore()
   })
 
-  it("applies clay destruction korting for maize in both NV and non-NV", async () => {
+  it("applies clay destruction korting for maize in both NV and non-NV for derogation farms", async () => {
     const dataSpy = spyNitrogenStandards([
       {
         b_lu_catalogue_match: ["nl_265"],
@@ -1943,35 +1973,41 @@ describe("NL2025 stikstof additional branch coverage", () => {
 
     setupGeoMock(1, 1)
     const nvResult = await calculateNL2025StikstofGebruiksNorm(
-      baseInput([
-        {
-          b_lu_catalogue: "nl_265",
-          b_lu_start: new Date(2024, 3, 1),
-          b_lu_end: new Date(2025, 1, 20),
-        } as NL2025NormsInputForCultivation,
-        {
-          b_lu_catalogue: "nl_maize_dest",
-          b_lu_start: new Date(2025, 2, 1),
-          b_lu_end: new Date(2025, 9, 1),
-        } as NL2025NormsInputForCultivation,
-      ]),
+      baseInput(
+        [
+          {
+            b_lu_catalogue: "nl_265",
+            b_lu_start: new Date(2024, 3, 1),
+            b_lu_end: new Date(2025, 1, 20),
+          } as NL2025NormsInputForCultivation,
+          {
+            b_lu_catalogue: "nl_maize_dest",
+            b_lu_start: new Date(2025, 2, 1),
+            b_lu_end: new Date(2025, 9, 1),
+          } as NL2025NormsInputForCultivation,
+        ],
+        { is_derogatie_bedrijf: true, has_grazing_intention: false },
+      ),
     )
     expect(nvResult.normSource).toContain("Korting: 65kg N/ha: graslandvernietiging")
 
     setupGeoMock(1, 0)
     const nonNvResult = await calculateNL2025StikstofGebruiksNorm(
-      baseInput([
-        {
-          b_lu_catalogue: "nl_265",
-          b_lu_start: new Date(2024, 3, 1),
-          b_lu_end: new Date(2025, 3, 20),
-        } as NL2025NormsInputForCultivation,
-        {
-          b_lu_catalogue: "nl_maize_dest",
-          b_lu_start: new Date(2025, 4, 1),
-          b_lu_end: new Date(2025, 9, 1),
-        } as NL2025NormsInputForCultivation,
-      ]),
+      baseInput(
+        [
+          {
+            b_lu_catalogue: "nl_265",
+            b_lu_start: new Date(2024, 3, 1),
+            b_lu_end: new Date(2025, 3, 20),
+          } as NL2025NormsInputForCultivation,
+          {
+            b_lu_catalogue: "nl_maize_dest",
+            b_lu_start: new Date(2025, 4, 1),
+            b_lu_end: new Date(2025, 9, 1),
+          } as NL2025NormsInputForCultivation,
+        ],
+        { is_derogatie_bedrijf: true, has_grazing_intention: false },
+      ),
     )
     expect(nonNvResult.normSource).toContain("Korting: 65kg N/ha: graslandvernietiging")
     dataSpy.mockRestore()

--- a/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.test.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.test.ts
@@ -2637,12 +2637,17 @@ describe("calculateNL2025StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
 
     const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
     // Catch crop is skipped in grassland destruction check, so no 65kg discount is applied
-    expect(result.normSource).not.toContain("Korting: 65kg N/ha: scheuren grasland")
+    expect(result.normSource).not.toContain("Korting: 65kg N/ha: graslandvernietiging")
   })
 
   it("should fallback to standard with subtypes when isVolgteelt is true but no volgteelt standard exists", async () => {
     setupGeoMock(1, 0)
     const dataSpy = spyNitrogenStandards([
+      {
+        b_lu_catalogue_match: ["nl_hoofd_only"],
+        cultivation_rvo_table2: "Gewas zonder subtypes",
+        norms: regionNorms(50),
+      } as unknown as NitrogenStandard,
       {
         b_lu_catalogue_match: ["nl_hoofd_only"],
         cultivation_rvo_table2: "Hoofdteelt gewas",

--- a/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.test.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.test.ts
@@ -2228,7 +2228,7 @@ describe("calculateNL2025StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
     const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
     expect(result.normValue).toBe(245)
     expect(result.normSource).toContain(
-      "Groenbemesters, niet-vlinderbloemige (geen norm: gezaaid op of na 1 september, voetnoot 7a) (0 kg N/ha)",
+      "Groenbemesters, niet-vlinderbloemige (geen extra ruimte: gezaaid op of na 1 september, voetnoot 7a) (0 kg N/ha)",
     )
   })
 
@@ -2255,7 +2255,7 @@ describe("calculateNL2025StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
     const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
     expect(result.normValue).toBe(245)
     expect(result.normSource).toContain(
-      "Groenbemesters, niet-vlinderbloemige (geen norm: vernietigd vóór 1 februari, voetnoot 7a) (0 kg N/ha)",
+      "Groenbemesters, niet-vlinderbloemige (geen extra ruimte: vernietigd vóór 1 februari, voetnoot 7a) (0 kg N/ha)",
     )
   })
 
@@ -2283,7 +2283,7 @@ describe("calculateNL2025StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
     // Tijdelijk grasland: 168 + Groenbemester 50% (40 * 0.5 = 20) = 188 kg N/ha
     expect(result.normValue).toBe(188)
     expect(result.normSource).toContain(
-      "Groenbemesters, niet-vlinderbloemige (50% norm na gras op bouwland, voetnoot 7a) (20 kg N/ha)",
+      "Groenbemesters, niet-vlinderbloemige (extra ruimte (50%) na gras op bouwland, voetnoot 7a) (20 kg N/ha)",
     )
   })
 
@@ -2366,7 +2366,34 @@ describe("calculateNL2025StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
     expect(result.normValue).toBe(185)
     expect(result.normSource).toContain("Akkerbouwgewassen, mais (geen derogatie) (185 kg N/ha)")
     expect(result.normSource).toContain(
-      "Groenbemesters, niet-vlinderbloemige (geen norm na maïs, voetnoot 2/6) (0 kg N/ha)",
+      "Groenbemesters, niet-vlinderbloemige (geen extra ruimte na maïs, voetnoot 2/6) (0 kg N/ha)",
+    )
+  })
+
+  it("should grant 0 norm with preceding crop explanation even if sown on or after 1 September", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_2014", // Consumptieaardappelen (not cereals/rapeseed/grass seed)
+          b_lu_start: new Date(2025, 3, 1),
+          b_lu_end: new Date(2025, 7, 30),
+        },
+        {
+          b_lu_catalogue: "nl_428", // Groenbemester sown after 1 Sep following potatoes
+          b_lu_start: new Date(2025, 8, 5), // Sep 5, 2025
+          b_lu_end: new Date(2026, 1, 15),
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    expect(result.normValue).toBe(250) // Potato norm only
+    expect(result.normSource).toContain(
+      "Groenbemesters, niet-vlinderbloemige (geen extra ruimte: niet geteeld na granen, graszaad of koolzaad, voetnoot 7a) (0 kg N/ha)",
     )
   })
 

--- a/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.test.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.test.ts
@@ -2489,4 +2489,238 @@ describe("calculateNL2025StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
     expect(result335.normValue).toBe(0)
     expect(result335.normSource).toContain("Geen plaatsingsruimte")
   })
+
+  it("should grant 0 norm for groenbemester with footnote 7a when there is no preceding crop", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_428", // Groenbemester gele mosterd
+          b_lu_start: new Date(2025, 7, 15), // Aug 15, 2025 (< Sep 1)
+          b_lu_end: new Date(2026, 1, 15), // Feb 15, 2026 (>= Feb 1)
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    expect(result.normValue).toBe(0)
+    expect(result.normSource).toContain(
+      "Groenbemesters, niet-vlinderbloemige (geen extra ruimte: geen voorafgaande teelt, voetnoot 7a)",
+    )
+  })
+
+  it("should evaluate Footnote 7b (Graszaadstoppel) before Sep 16 and on/after Sep 16", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const dataSpy = spyNitrogenStandards([
+      {
+        b_lu_catalogue_match: ["nl_graszaad_stoppel"],
+        cultivation_rvo_table2: "Graszaadstoppel ter vernietiging in najaar of vroege voorjaar",
+        type: "groenbemester",
+        norms: regionNorms(60),
+      } as unknown as NitrogenStandard,
+    ])
+
+    // Sown before Sep 16 (Sep 10) -> qualifies for norm
+    const inputBefore = baseInput([
+      {
+        b_lu_catalogue: "nl_graszaad_stoppel",
+        b_lu_start: new Date(2025, 8, 10),
+        b_lu_end: new Date(2026, 1, 1),
+      } as NL2025NormsInputForCultivation,
+    ])
+    const resultBefore = await calculateNL2025StikstofGebruiksNorm(inputBefore)
+    expect(resultBefore.normValue).toBe(60)
+    expect(resultBefore.normSource).toContain("(graszaadstoppel, voetnoot 7b)")
+
+    // Sown on or after Sep 16 (Sep 20) -> 0 norm
+    const inputAfter = baseInput([
+      {
+        b_lu_catalogue: "nl_graszaad_stoppel",
+        b_lu_start: new Date(2025, 8, 20),
+        b_lu_end: new Date(2026, 1, 1),
+      } as NL2025NormsInputForCultivation,
+    ])
+    const resultAfter = await calculateNL2025StikstofGebruiksNorm(inputAfter)
+    expect(resultAfter.normValue).toBe(0)
+    expect(resultAfter.normSource).toContain(
+      "(geen extra ruimte: niet voldaan aan voorwaarden graszaadstoppel, voetnoot 7b)",
+    )
+
+    dataSpy.mockRestore()
+  })
+
+  it("should filter out cultivations starting after the norm year", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_233", // Wintertarwe
+          b_lu_start: new Date(2025, 2, 1),
+          b_lu_end: new Date(2025, 7, 1),
+        },
+        {
+          b_lu_catalogue: "nl_233",
+          b_lu_start: new Date(2026, 2, 1), // Started after 2025
+          b_lu_end: new Date(2026, 7, 1),
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    expect(result.normValue).toBe(245)
+    expect(result.normSource).toBe("Akkerbouwgewassen, wintertarwe.")
+  })
+
+  it("should fallback to groene braak when cultivations array is empty", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    expect(result.normValue).toBe(0)
+    expect(result.normSource).toContain("Geen plaatsingsruimte")
+  })
+
+  it("should set norm 0 with (heringezaaid) for multiple grass crops in the same year", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_265", // Grasland
+          b_lu_start: new Date(2025, 2, 1),
+          b_lu_end: new Date(2025, 5, 1),
+        },
+        {
+          b_lu_catalogue: "nl_265", // Grasland herinzaai
+          b_lu_start: new Date(2025, 5, 2),
+          b_lu_end: new Date(2025, 9, 1),
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    expect(result.normSource).toContain("(heringezaaid)")
+  })
+
+  it("should exclude previous grass catch crop from grassland destruction discount", async () => {
+    setupGeoMock(4, 0) // zand_nwc, non-NV
+    const mockInput: NL2025NormsInput = {
+      farm: { is_derogatie_bedrijf: false, has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: sandCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_265", // Grassland
+          b_lu_start: new Date(2024, 7, 15), // August 2024 -> catch crop (month >= 7)
+          b_lu_end: new Date(2025, 1, 15), // Feb 15, 2025
+        },
+        {
+          b_lu_catalogue: "nl_259", // Mais
+          b_lu_start: new Date(2025, 3, 1),
+          b_lu_end: new Date(2025, 8, 1),
+        },
+      ] as NL2025NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2025StikstofGebruiksNorm(mockInput)
+    // Catch crop is skipped in grassland destruction check, so no 65kg discount is applied
+    expect(result.normSource).not.toContain("Korting: 65kg N/ha: scheuren grasland")
+  })
+
+  it("should fallback to standard with subtypes when isVolgteelt is true but no volgteelt standard exists", async () => {
+    setupGeoMock(1, 0)
+    const dataSpy = spyNitrogenStandards([
+      {
+        b_lu_catalogue_match: ["nl_hoofd_only"],
+        cultivation_rvo_table2: "Hoofdteelt gewas",
+        norms: regionNorms(95),
+        sub_types: [
+          {
+            omschrijving: "specifiek",
+            period_start_month: 1,
+            period_end_month: 12,
+            norms: regionNorms(95),
+          },
+        ],
+      } as unknown as NitrogenStandard,
+      {
+        b_lu_catalogue_match: ["nl_preceding"],
+        cultivation_rvo_table2: "Preceding gewas",
+        norms: regionNorms(100),
+      } as unknown as NitrogenStandard,
+    ])
+
+    const result = await calculateNL2025StikstofGebruiksNorm(
+      baseInput([
+        {
+          b_lu_catalogue: "nl_preceding",
+          b_lu_start: new Date(2025, 2, 1),
+          b_lu_end: new Date(2025, 5, 1),
+        } as NL2025NormsInputForCultivation,
+        {
+          b_lu_catalogue: "nl_hoofd_only",
+          b_lu_start: new Date(2025, 5, 2),
+          b_lu_end: new Date(2025, 9, 1),
+        } as NL2025NormsInputForCultivation,
+      ]),
+    )
+
+    expect(result.normValue).toBe(195)
+    dataSpy.mockRestore()
+  })
+
+  it("should handle subtype sort with undefined period_start_day and period_end_day", async () => {
+    setupGeoMock(1, 0)
+    const dataSpy = spyNitrogenStandards([
+      {
+        b_lu_catalogue_match: ["nl_subtype_null_days"],
+        cultivation_rvo_table2: "Subtype null days crop",
+        norms: regionNorms(0),
+        sub_types: [
+          {
+            omschrijving: "vroeg",
+            period_start_month: 3,
+            period_start_day: undefined,
+            period_end_month: 6,
+            period_end_day: undefined,
+            norms: regionNorms(130),
+          },
+          {
+            omschrijving: "laat",
+            period_start_month: 3,
+            period_start_day: undefined,
+            period_end_month: 10,
+            period_end_day: undefined,
+            norms: regionNorms(150),
+          },
+        ],
+      } as unknown as NitrogenStandard,
+    ])
+
+    const result = await calculateNL2025StikstofGebruiksNorm(
+      baseInput([
+        {
+          b_lu_catalogue: "nl_subtype_null_days",
+          b_lu_start: new Date(2025, 2, 1),
+          b_lu_end: new Date(2025, 10, 15),
+        } as NL2025NormsInputForCultivation,
+      ]),
+    )
+
+    expect(result.normValue).toBe(150)
+    dataSpy.mockRestore()
+  })
 })

--- a/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.ts
@@ -661,21 +661,9 @@ function calculateSingleCultivationNorm(
 
   if (hasMaizeBefore && isGroenbemesterOrCatchOrTempGrass) {
     normValue = new Decimal(0)
-    noteText = " (geen norm na maïs, voetnoot 2/6)"
+    noteText = " (geen extra ruimte na maïs, voetnoot 2/6)"
   } else if (selectedStandard.cultivation_rvo_table2 === "Groenbemesters, niet-vlinderbloemige") {
     // Footnote 7a: Groenbemester conditions
-    const isSownBeforeSept1 =
-      cultivation.b_lu_start &&
-      (cultivation.b_lu_start.getFullYear() < 2025 ||
-        (cultivation.b_lu_start.getFullYear() === 2025 &&
-          (cultivation.b_lu_start.getMonth() < 8 ||
-            (cultivation.b_lu_start.getMonth() === 8 &&
-              cultivation.b_lu_start.getDate() === 1 &&
-              cultivation.b_lu_start.getHours() === 0))))
-
-    const isNotDestroyedBeforeFeb1 =
-      !cultivation.b_lu_end || cultivation.b_lu_end >= new Date(2026, 1, 1)
-
     const immediatePrecedingCrop =
       prevCultivationsInYear.length > 0
         ? prevCultivationsInYear[prevCultivationsInYear.length - 1]
@@ -693,25 +681,40 @@ function calculateSingleCultivationNorm(
 
     const isSandyOrLoess = ["zand_nwc", "zand_zuid", "loess"].includes(region)
 
-    if (!isSownBeforeSept1) {
+    const isSownBeforeSept1 =
+      cultivation.b_lu_start &&
+      (cultivation.b_lu_start.getFullYear() < 2025 ||
+        (cultivation.b_lu_start.getFullYear() === 2025 &&
+          (cultivation.b_lu_start.getMonth() < 8 ||
+            (cultivation.b_lu_start.getMonth() === 8 &&
+              cultivation.b_lu_start.getDate() === 1 &&
+              cultivation.b_lu_start.getHours() === 0))))
+
+    const isNotDestroyedBeforeFeb1 =
+      !cultivation.b_lu_end || cultivation.b_lu_end >= new Date(2026, 1, 1)
+
+    if (!immediatePrecedingCrop) {
       normValue = new Decimal(0)
-      noteText = " (geen norm: gezaaid op of na 1 september, voetnoot 7a)"
+      noteText = " (geen extra ruimte: geen voorafgaande teelt, voetnoot 7a)"
+    } else if (
+      !isPrecedingCerealOrRapeseedOrGrassSeed &&
+      !(isSandyOrLoess && isPrecedingGrasOpBouwland)
+    ) {
+      normValue = new Decimal(0)
+      noteText = " (geen extra ruimte: niet geteeld na granen, graszaad of koolzaad, voetnoot 7a)"
+    } else if (!isSownBeforeSept1) {
+      normValue = new Decimal(0)
+      noteText = " (geen extra ruimte: gezaaid op of na 1 september, voetnoot 7a)"
     } else if (!isNotDestroyedBeforeFeb1) {
       normValue = new Decimal(0)
-      noteText = " (geen norm: vernietigd vóór 1 februari, voetnoot 7a)"
-    } else if (!immediatePrecedingCrop) {
-      normValue = new Decimal(0)
-      noteText = " (geen norm: geen voorafgaande teelt, voetnoot 7a)"
+      noteText = " (geen extra ruimte: vernietigd vóór 1 februari, voetnoot 7a)"
     } else if (isPrecedingCerealOrRapeseedOrGrassSeed) {
       // 100% of norm
       noteText = " (volgteelt na granen, graszaad of koolzaad, voetnoot 7a)"
     } else if (isSandyOrLoess && isPrecedingGrasOpBouwland) {
       // 50% of norm on sand or loess after grass on arable land
       normValue = normValue.dividedBy(2)
-      noteText = " (50% norm na gras op bouwland, voetnoot 7a)"
-    } else {
-      normValue = new Decimal(0)
-      noteText = " (geen norm: niet geteeld na granen, graszaad of koolzaad, voetnoot 7a)"
+      noteText = " (extra ruimte (50%) na gras op bouwland, voetnoot 7a)"
     }
   }
 
@@ -729,7 +732,7 @@ function calculateSingleCultivationNorm(
       noteText = " (graszaadstoppel, voetnoot 7b)"
     } else {
       normValue = new Decimal(0)
-      noteText = " (geen norm: niet voldaan aan voorwaarden graszaadstoppel, voetnoot 7b)"
+      noteText = " (geen extra ruimte: niet voldaan aan voorwaarden graszaadstoppel, voetnoot 7b)"
     }
   }
 

--- a/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.ts
@@ -897,8 +897,8 @@ export async function calculateNL2025StikstofGebruiksNorm(
   })
 
   // Determine which index in sortedCultivations is the hoofdteelt
-  const hoofdteeltIndex = sortedCultivations.findIndex(
-    (c) => (c.b_lu && hoofdteelt.b_lu ? c.b_lu === hoofdteelt.b_lu : c === hoofdteelt),
+  const hoofdteeltIndex = sortedCultivations.findIndex((c) =>
+    c.b_lu && hoofdteelt.b_lu ? c.b_lu === hoofdteelt.b_lu : c === hoofdteelt,
   )
 
   let totalNormValue = new Decimal(0)

--- a/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.ts
@@ -536,9 +536,9 @@ function calculateKorting(
         ) {
           isValidDestruction = true
         }
-      } else if (clayOrPeatRegions.includes(region)) {
+      } else if (clayOrPeatRegions.includes(region) && is_derogatie_bedrijf) {
         if (is_nv_area) {
-          // Clay/Peat NV: Feb 1 - Mar 15
+          // Clay/Peat NV (Derogation): Feb 1 - Mar 15
           if (
             destructionDate >= new Date(currentYear, 1, 1) &&
             destructionDate <= new Date(currentYear, 2, 15)
@@ -546,7 +546,7 @@ function calculateKorting(
             isValidDestruction = true
           }
         } else {
-          // Clay/Peat Non-NV: Feb 1 - May 31
+          // Clay/Peat Non-NV (Derogation): Feb 1 - May 31
           if (
             destructionDate >= new Date(currentYear, 1, 1) &&
             destructionDate <= new Date(currentYear, 4, 31)
@@ -706,15 +706,20 @@ function calculateSingleCultivationNorm(
   let noteText = ""
 
   // Footnote 2 & 6: Suppression of groenbemester, tijdelijk grasland and vanggewas norms after maize
+  const immediatePrecedingCrop =
+    prevCultivationsInYear.length > 0
+      ? prevCultivationsInYear[prevCultivationsInYear.length - 1]
+      : undefined
+
   const hasMaizeBefore =
     !isHoofdteelt &&
-    prevCultivationsInYear.some(
-      (c) =>
-        maisCodes.includes(c.b_lu_catalogue) ||
+    Boolean(
+      immediatePrecedingCrop &&
+      (maisCodes.includes(immediatePrecedingCrop.b_lu_catalogue) ||
         nitrogenStandardsData
-          .find((ns) => ns.b_lu_catalogue_match.includes(c.b_lu_catalogue))
+          .find((ns) => ns.b_lu_catalogue_match.includes(immediatePrecedingCrop.b_lu_catalogue))
           ?.cultivation_rvo_table2.toLowerCase()
-          .includes("mais"),
+          .includes("mais")),
     )
 
   const isGroenbemesterOrCatchOrTempGrass =
@@ -728,11 +733,6 @@ function calculateSingleCultivationNorm(
     noteText = " (geen extra ruimte na maïs, voetnoot 2/6)"
   } else if (selectedStandard.cultivation_rvo_table2 === "Groenbemesters, niet-vlinderbloemige") {
     // Footnote 7a: Groenbemester conditions
-    const immediatePrecedingCrop =
-      prevCultivationsInYear.length > 0
-        ? prevCultivationsInYear[prevCultivationsInYear.length - 1]
-        : undefined
-
     const isPrecedingCerealOrRapeseedOrGrassSeed =
       immediatePrecedingCrop &&
       (graanCodes.includes(immediatePrecedingCrop.b_lu_catalogue) ||
@@ -748,11 +748,7 @@ function calculateSingleCultivationNorm(
     const isSownBeforeSept1 =
       cultivation.b_lu_start &&
       (cultivation.b_lu_start.getFullYear() < 2025 ||
-        (cultivation.b_lu_start.getFullYear() === 2025 &&
-          (cultivation.b_lu_start.getMonth() < 8 ||
-            (cultivation.b_lu_start.getMonth() === 8 &&
-              cultivation.b_lu_start.getDate() === 1 &&
-              cultivation.b_lu_start.getHours() === 0))))
+        (cultivation.b_lu_start.getFullYear() === 2025 && cultivation.b_lu_start.getMonth() < 8))
 
     const isNotDestroyedBeforeFeb1 =
       !cultivation.b_lu_end || cultivation.b_lu_end >= new Date(2026, 1, 1)
@@ -790,7 +786,7 @@ function calculateSingleCultivationNorm(
     const isBeforeSept16 =
       !cultivation.b_lu_start ||
       cultivation.b_lu_start.getMonth() < 8 ||
-      (cultivation.b_lu_start.getMonth() === 8 && cultivation.b_lu_start.getDate() <= 16)
+      (cultivation.b_lu_start.getMonth() === 8 && cultivation.b_lu_start.getDate() < 16)
 
     if (isBeforeSept16) {
       noteText = " (graszaadstoppel, voetnoot 7b)"
@@ -805,7 +801,7 @@ function calculateSingleCultivationNorm(
   const hasGrassBeforeInYear = prevCultivationsInYear.some((c) =>
     nonBouwlandCodes.includes(c.b_lu_catalogue),
   )
-  if (!isHoofdteelt && isGrass && hasGrassBeforeInYear) {
+  if (isGrass && hasGrassBeforeInYear) {
     normValue = new Decimal(0)
     noteText = " (heringezaaid)"
   }
@@ -902,7 +898,7 @@ export async function calculateNL2025StikstofGebruiksNorm(
 
   // Determine which index in sortedCultivations is the hoofdteelt
   const hoofdteeltIndex = sortedCultivations.findIndex(
-    (c) => c.b_lu_catalogue === hoofdteelt.b_lu_catalogue,
+    (c) => (c.b_lu && hoofdteelt.b_lu ? c.b_lu === hoofdteelt.b_lu : c === hoofdteelt),
   )
 
   let totalNormValue = new Decimal(0)

--- a/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.ts
@@ -127,7 +127,7 @@ export async function getRegion(b_centroid: Field["b_centroid"]): Promise<Region
  *   (e.g., "zand_nwc", "zand_zuid", "klei", "veen", "loess") that apply to the specific cultivation and conditions.
  *   Returns `undefined` if no applicable norms can be found based on the provided criteria.
  */
-function getNormsForCultivation(
+export function getNormsForCultivation(
   selectedStandard: NitrogenStandard,
   b_lu_end: Date,
   b_lu_start: Date | null | undefined,

--- a/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.ts
@@ -276,13 +276,25 @@ export function getNormsForCultivation(
 
 /**
  * Determines the specific sub-type 'omschrijving' for a cultivation that is part of a larger group.
- * This is necessary for standards that use sub_types to differentiate norms, e.g., for winter vs. summer varieties.
  *
- * @param cultivation - The specific cultivation for which to determine the sub-type.
- * @param standard - The matched NitrogenStandard which may contain sub_types.
- * @param is_derogatie_bedrijf - Optional. A boolean indicating if the farm operates under derogation.
- * @param cultivations - An array of cultivation objects for the current and previous year.
- * @returns The 'omschrijving' of the matching sub-type as a string, or undefined if no specific sub-type applies.
+ * Sub-types in RVO Tabel 2 differentiate nitrogen norms based on crop management, cultivation history,
+ * or botanical characteristics:
+ * - **Grasland**: Differentiates between grazing (`beweiden`) and pure mowing (`volledig maaien`).
+ * - **Aardappel**: Matches specific potato varieties to standard groupings (e.g. early, late, seed, starch).
+ * - **Mais**: Differentiates between derogation and non-derogation farm status (2025 only).
+ * - **Luzerne**: Differentiates first-year (`eerste jaar`) from subsequent years (`volgende jaren`) based on prior-year presence.
+ * - **Koolzaad**: Differentiates winter (`winter`, `nl_1922`) from summer (`zomer`, `nl_1923`) varieties.
+ * - **Gras voor industriële verwerking / Graszaad / Roodzwenkgras**: Differentiates establishment / 1st year from multi-year / overjarig stands.
+ * - **Zaaiui / Winterui**: Differentiates 1st year (`nl_1932`) from 2nd year (`nl_1933`).
+ * - **Bladgewassen (Spinazie, Slasoorten, Andijvie)**: Differentiates 1st cultivation (`1e teelt`) for the main crop from subsequent cultivation (`volgteelt`).
+ *
+ * @param cultivation - The cultivation object being evaluated.
+ * @param standard - The matching `NitrogenStandard` definition from Tabel 2.
+ * @param is_derogatie_bedrijf - Indicates if the farm holds a derogation permit (relevant for maize in 2025).
+ * @param cultivations - All cultivations on the field (used to inspect cultivation history across years).
+ * @param has_grazing_intention - Grazing intention flag for grassland (mowing vs grazing).
+ * @param isHoofdteelt - Whether this cultivation is the designated main crop (`hoofdteelt`) of the year.
+ * @returns The matching sub-type description key, or `undefined` if no specific sub-type applies.
  */
 function determineSubTypeOmschrijving(
   cultivation: NL2025NormsInputForCultivation,
@@ -395,8 +407,28 @@ function determineSubTypeOmschrijving(
 }
 
 /**
- * Calculates the "korting" (reduction) on the nitrogen usage norm based on the presence
- * of winter crops or catch crops in the previous year.
+ * Calculates statutory reductions ("kortingen") on the annual nitrogen usage norm for 2025.
+ *
+ * Implements three statutory reduction mechanisms:
+ * 1. **Grassland renewal (Graslandvernieuwing, Footnote 14)**:
+ *    - Applies a **50 kg N/ha** reduction when grassland is renewed (gras-na-gras transition) between 1 June and 31 August.
+ *    - In 2025: Applies on sand and loess soils for all farms; on clay and peat soils only for derogation permit holders.
+ * 2. **Grassland destruction (Graslandvernietiging / Scheuren)**:
+ *    - Applies a **65 kg N/ha** reduction when grassland is converted to arable land (gras-naar-bouwland transition)
+ *      for maize or eligible potato cultivations (excluding seed potatoes and early harvest varieties).
+ *    - Allowed destruction windows:
+ *      - Sand & Loess: 1 February – 10 May.
+ *      - Clay & Peat (NV-gebied): 1 February – 15 March.
+ *      - Clay & Peat (Non-NV): 1 February – 31 May.
+ *    - Catch crops (vanggewas) sown in autumn of the previous year are excluded from triggering grassland destruction korting.
+ * 3. **Article 28d Meststoffenwet (Catch crops and winter crops after sand/loess main crops)**:
+ *    - Evaluated by `calculateVanggewasWinterteeltKorting` anchored to the main crop of year N-1.
+ *
+ * @param cultivations - Array of cultivations across current and preceding years.
+ * @param region - Soil region (`zand_nwc`, `zand_zuid`, `loess`, `klei`, `veen`).
+ * @param is_derogatie_bedrijf - Farm derogation permit status in 2025.
+ * @param is_nv_area - Flag indicating if the parcel is located in a nutrient-polluted zone (NV-gebied).
+ * @returns An object containing the total reduction amount (Decimal) and formatted descriptive text.
  */
 function calculateKorting(
   cultivations: NL2025NormsInputForCultivation[],
@@ -545,7 +577,39 @@ function calculateKorting(
 }
 
 /**
- * Calculates the nitrogen norm for a single cultivation in 2025.
+ * Calculates the nitrogen usage standard for an individual cultivation in 2025 according to RVO Tabel 2.
+ *
+ * This function performs multi-step agronomic compliance checks:
+ * 1. **Standard & Subtype Resolution**: Matches `b_lu_catalogue` to Tabel 2 records. For non-main crops (`!isHoofdteelt`),
+ *    it prioritizes explicit `volgteelt` entries where available.
+ * 2. **Regional & NV-area Norm Selection**: Fetches the applicable base norm in kg N/ha for the field's soil region
+ *    and NV-gebied designation.
+ * 3. **Footnote 2 & 6 Compliance (Maïs follow-up suppression)**:
+ *    - Suppresses norms (sets 0 kg N/ha) for green manures (`Groenbemesters`), catch crops (`is_vanggewas`),
+ *      and temporary grassland (`tijdelijkGraslandCodes`) following maize on the same field in the calendar year.
+ * 4. **Footnote 7a Compliance (Green manure conditions)**:
+ *    - Green manure norms (`Groenbemesters, niet-vlinderbloemige`) are conditional upon:
+ *      - Having an immediate preceding crop in the same calendar year.
+ *      - Preceding crop being a cereal (`graanCodes`), grass seed (`graszaadCodes`), or rapeseed (`koolzaadCodes`) for a full 100% norm.
+ *      - On sand/loess following temporary grassland (`tijdelijkGraslandCodes`), granting a 50% norm.
+ *      - Sowing date strictly before 1 September.
+ *      - Standing until at least 1 February of the following year.
+ *    - If conditions are unmet, grants 0 kg N/ha with an explanatory status note.
+ * 5. **Footnote 7b Compliance (Graszaadstoppel)**:
+ *    - Requires cultivation start on or before 16 September; otherwise grants 0 kg N/ha.
+ * 6. **Grassland Renewal Sod Continuation**:
+ *    - Resown grassland (`isGrass && hasGrassBeforeInYear`) shares the single annual grassland allowance (0 kg N/ha for 2nd sod).
+ *
+ * @param cultivation - The cultivation being calculated.
+ * @param isHoofdteelt - True if this cultivation is the designated main crop of the year.
+ * @param prevCultivationsInYear - Prior cultivations in the same calendar year on this parcel.
+ * @param cultivations - Complete array of cultivations on the field.
+ * @param is_derogatie_bedrijf - Farm derogation status in 2025.
+ * @param has_grazing_intention - Grazing intention for grassland parcels.
+ * @param region - Soil region classification.
+ * @param is_nv_area - Nutrient-polluted area (NV-gebied) indicator.
+ * @returns Object containing the calculated norm value, standard name, subtype text, and explanatory footnote note.
+ * @throws {NormNotApplicableError} If no matching crop standard exists in Tabel 2.
  */
 function calculateSingleCultivationNorm(
   cultivation: NL2025NormsInputForCultivation,
@@ -756,13 +820,28 @@ function calculateSingleCultivationNorm(
 }
 
 /**
- * Determines the 'gebruiksnorm' (usage standard) for nitrogen for a given cultivation plan in 2025
- * by accumulating per-teelt norms across all crops in the calendar year according to
- * Dutch RVO's "Tabel 2 Stikstof landbouwgrond 2025".
+ * Determines the 'gebruiksnorm' (nitrogen application standard) for a given field and cultivation plan in 2025
+ * by accumulating per-teelt norms across all active crops in the calendar year according to
+ * Dutch RVO "Tabel 2 Stikstof landbouwgrond 2025".
  *
- * @remarks
- * See `fdm-docs/docs/insights/fertilizer-application-norms/nl/2025/stikstofgebruiksnorm.md` for full documentation
- * of implemented rules, footnotes (2, 6, 7a, 7b, 14, 15, 16), and out-of-scope provisions.
+ * ### Agronomic & Legal Workflow:
+ * 1. **Buffer Strip Check**: Parcels marked with `b_bufferstrip` receive 0 kg N/ha.
+ * 2. **Geographical Resolution**: Determines soil type (`getRegion`) and NV-gebied status (`isFieldInNVGebied`).
+ * 3. **Main Crop Identification**: Identifies the statutory `hoofdteelt` (present between 15 May and 15 July).
+ * 4. **Multi-Teelt Accumulation**:
+ *    - Iterates over all active cultivations in the calendar year (including overwintering main crops).
+ *    - The main crop receives its 1st cultivation standard (`1e teelt`).
+ *    - Successive crops receive volgteelt / subtype standards with applicable footnote checks (footnotes 2, 6, 7a, 7b).
+ * 5. **Statutory Reductions ("Kortingen")**:
+ *    - Grassland renewal reduction (50 kg N/ha, footnote 14).
+ *    - Grassland destruction reduction (65 kg N/ha).
+ *    - Article 28d catch-crop / winter-crop shortfall reductions.
+ * 6. **Floor & Formatting**: Enforces non-negative norm floor (min 0) and generates a detailed audit breakdown string.
+ *
+ * @param input - Input data containing farm settings, field centroid/bufferstrip, and cultivation schedule.
+ * @returns An object containing the aggregated `normValue` (in kg N/ha) and the descriptive `normSource`.
+ *
+ * @see `fdm-docs/docs/insights/fertilizer-application-norms/nl/2025/stikstofgebruiksnorm.md`
  */
 export async function calculateNL2025StikstofGebruiksNorm(
   input: NL2025NormsInput,

--- a/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.ts
@@ -13,7 +13,14 @@ import pkg from "../../../../package"
 import { getGeoTiffValue } from "../../../../shared/geotiff"
 import { findHoofdteelt } from "../../../../shared/hoofdteelt"
 import { getFdmPublicDataUrl } from "../../../../shared/public-data-url"
-import { nonBouwlandCodes } from "../../constant"
+import {
+  graanCodes,
+  graszaadCodes,
+  koolzaadCodes,
+  maisCodes,
+  nonBouwlandCodes,
+  tijdelijkGraslandCodes,
+} from "../../constant"
 import { nitrogenStandardsData } from "./stikstofgebruiksnorm-data"
 import { calculateVanggewasWinterteeltKorting } from "./vanggewas-winterteelt"
 
@@ -119,31 +126,6 @@ export async function getRegion(b_centroid: Field["b_centroid"]): Promise<Region
  * @returns A `NormsByRegion` object containing standard and NV-gebied norms for all regions
  *   (e.g., "zand_nwc", "zand_zuid", "klei", "veen", "loess") that apply to the specific cultivation and conditions.
  *   Returns `undefined` if no applicable norms can be found based on the provided criteria.
- *
- * @remarks
- * The function prioritizes norm selection based on the following hierarchy:
- * 1.  **Sub-Type Norms (e.g., Temporary Grasslands)**:
- *     If `selectedStandard` has `sub_types` defined (e.g., for temporary grasslands),
- *     it checks if the `b_lu_end` date falls within any of the specified `period_start_month`
- *     and `period_end_month` ranges. If a matching sub-type period is found, its associated
- *     norms are returned. This ensures that time-sensitive norms are correctly applied.
- * 2.  **Variety-Specific Norms (e.g., Potatoes)**:
- *     If the `selectedStandard` is for "aardappel" (potato) and `b_lu_variety` is provided,
- *     the function checks if the variety matches any in `varieties_hoge_norm` (high norms)
- *     or `varieties_lage_norm` (low norms). If a match is found, the corresponding norms
- *     (`norms_hoge_norm` or `norms_lage_norm`) are returned. If the variety doesn't match
- *     these specific lists, it falls back to `norms_overig` (other) potato norms if available.
- * 3.  **Derogation-Specific Norms (e.g., Maize)**:
- *     If the `selectedStandard` is for "akkerbouw" and specifically "Akkerbouwgewassen, mais",
- *     it checks the `is_derogatie_bedrijf` status. If the farm is derogated, `derogatie_norms`
- *     are returned; otherwise, `non_derogatie_norms` are returned. This ensures that norms
- *     are correctly applied based on the farm's legal status.
- * 4.  **Default Norms**:
- *     If none of the above specific conditions are met, the function defaults to returning
- *     the primary `norms` defined directly within the `selectedStandard` object.
- *
- * This structured approach ensures that the most specific and applicable nitrogen norm
- * is always retrieved for the given cultivation context.
  */
 function getNormsForCultivation(
   selectedStandard: NitrogenStandard,
@@ -211,13 +193,14 @@ function getNormsForCultivation(
           sub.period_start_month > 1
 
         if (isVanaf) {
-          // If it's a "tot minstens" period (implied by end month < 12), it must also last until endPeriod.
+          // If it's a "tot minstens" period (implied by end month < 12), it must also last until endPeriod,
+          // and the crop must have been sown on or before endPeriod (cannot start after the period has ended).
           if (
             sub.period_end_month !== null &&
             sub.period_end_month !== undefined &&
             sub.period_end_month < 12
           ) {
-            return startDate >= startPeriod && endDate >= endPeriod
+            return startDate >= startPeriod && startDate <= endPeriod && endDate >= endPeriod
           }
           // For "vanaf X" (without "tot minstens", e.g. "vanaf 15 oktober"), we only check if it starts on or after X.
           return startDate >= startPeriod
@@ -307,6 +290,7 @@ function determineSubTypeOmschrijving(
   is_derogatie_bedrijf: boolean | undefined,
   cultivations: NL2025NormsInputForCultivation[],
   has_grazing_intention: boolean | undefined,
+  isHoofdteelt: boolean = true,
 ): string | undefined {
   // Grasland logic based on grazing intention
   if (standard.type === "grasland") {
@@ -396,7 +380,7 @@ function determineSubTypeOmschrijving(
     if (cultivation.b_lu_catalogue === "nl_1933") return "2e jaars"
   }
 
-  // Bladgewassen logic based on hoofdteelt
+  // Bladgewassen logic based on hoofdteelt vs volgteelt
   const bladgewasRvoTable2s = [
     "Bladgewassen, Spinazie",
     "Bladgewassen, Slasoorten",
@@ -404,21 +388,8 @@ function determineSubTypeOmschrijving(
   ]
 
   if (bladgewasRvoTable2s.includes(standard.cultivation_rvo_table2)) {
-    const hoofdteeltCatalogue = findHoofdteelt(cultivations, 2025, false, true).b_lu_catalogue
-    if (cultivation.b_lu_catalogue === hoofdteeltCatalogue) {
-      return "1e teelt"
-    }
-    // TODO: Implement volgteelt logic here later
+    return isHoofdteelt ? "1e teelt" : "volgteelt"
   }
-
-  /*
-   * --- Cultivations with Unclear Differentiation Logic (may require matching on b_lu string or external context): ---
-   * - Bladgewassen, Bladgewassen overig (e.g., "eenmalige oogst" vs. "meermalige oogst")
-   * - Kruiden (differentiating between bladgewas, wortelgewassen, zaadgewassen)
-   * - Bloembollengewassen, Iris (e.g., "grofbollig" vs. "fijnbollig")
-   * - Bloembollengewassen, Krokus (e.g., "grote gele" vs. "overig")
-   * - Bloembollengewassen, Gladiool (e.g., "pitten" vs. "kralen")
-   */
 
   return undefined
 }
@@ -426,10 +397,6 @@ function determineSubTypeOmschrijving(
 /**
  * Calculates the "korting" (reduction) on the nitrogen usage norm based on the presence
  * of winter crops or catch crops in the previous year.
- *
- * @param cultivations - An array of cultivation objects for the current and previous year.
- * @param region - The soil region of the field (e.g., "zand_nwc", "zand_zuid", "loess").
- * @returns An object containing the reduction amount in kilograms of nitrogen per hectare (kg N/ha) and a description.
  */
 function calculateKorting(
   cultivations: NL2025NormsInputForCultivation[],
@@ -438,6 +405,7 @@ function calculateKorting(
   is_nv_area: boolean,
 ): { amount: Decimal; description: string } {
   const currentYear = 2025
+  const previousYear = currentYear - 1
 
   const sandyOrLoessRegions: RegionKey[] = ["zand_nwc", "zand_zuid", "loess"]
   const clayOrPeatRegions: RegionKey[] = ["klei", "veen"]
@@ -473,57 +441,19 @@ function calculateKorting(
       const renewalDate = prevCult.b_lu_end
       let isValidRenewal = false
 
+      // Footnote 14 (2025): Renewal between 1 June and 31 August
+      // On sand and loess: all farms. On clay and peat: only for derogation farms.
+      const isJuneToAugust =
+        renewalDate >= new Date(currentYear, 5, 1) && // June 1
+        renewalDate <= new Date(currentYear, 7, 31) // Aug 31
+
       if (sandyOrLoessRegions.includes(region)) {
-        // Sand/Loess: June 1 - August 31
-        if (
-          renewalDate >= new Date(currentYear, 5, 1) && // June 1
-          renewalDate <= new Date(currentYear, 7, 31) // Aug 31
-        ) {
+        if (isJuneToAugust) {
           isValidRenewal = true
-        } else {
-          throw new NormNotApplicableError(
-            "Graslandvernieuwing op zand- en lössgrond is alleen toegestaan tussen 1 juni en 31 augustus.",
-          )
         }
       } else if (clayOrPeatRegions.includes(region)) {
-        if (is_derogatie_bedrijf) {
-          if (is_nv_area) {
-            // Derogation + NV: June 1 - August 31
-            if (
-              renewalDate >= new Date(currentYear, 5, 1) &&
-              renewalDate <= new Date(currentYear, 7, 31)
-            ) {
-              isValidRenewal = true
-            } else {
-              throw new NormNotApplicableError(
-                "Graslandvernieuwing op klei- en veengrond (derogatie + NV-gebied) is alleen toegestaan tussen 1 juni en 31 augustus.",
-              )
-            }
-          } else {
-            // Derogation + Non-NV: June 1 - September 15
-            if (
-              renewalDate >= new Date(currentYear, 5, 1) &&
-              renewalDate <= new Date(currentYear, 8, 15)
-            ) {
-              isValidRenewal = true
-            } else {
-              throw new NormNotApplicableError(
-                "Graslandvernieuwing op klei- en veengrond (derogatie + niet NV-gebied) is alleen toegestaan tussen 1 juni en 15 september.",
-              )
-            }
-          }
-        } else {
-          // Non-Derogation: February 1 - September 15
-          if (
-            renewalDate >= new Date(currentYear, 1, 1) &&
-            renewalDate <= new Date(currentYear, 8, 15)
-          ) {
-            isValidRenewal = true
-          } else {
-            throw new NormNotApplicableError(
-              "Graslandvernieuwing op klei- en veengrond (geen derogatie) is alleen toegestaan tussen 1 februari en 15 september.",
-            )
-          }
+        if (is_derogatie_bedrijf && isJuneToAugust) {
+          isValidRenewal = true
         }
       }
 
@@ -534,19 +464,35 @@ function calculateKorting(
     }
 
     // 2. Grassland Destruction (Gras-naar-Bouwland) -> 65 kg N/ha korting
-    // Applies if New Crop is Maize OR Consumption/Factory/Starch Potatoes (NOT Seed Potatoes)
+    // Applies if New Crop is Maize OR Consumption/Factory/Starch Potatoes (NOT Seed Potatoes or early potatoes)
+    const prevStandard = nitrogenStandardsData.find((ns) =>
+      ns.b_lu_catalogue_match.includes(prevCult.b_lu_catalogue),
+    )
     const isMaize = currStandard?.cultivation_rvo_table2.includes("mais")
     const isPotato = currStandard?.type === "aardappel"
-    const isSeedPotato =
+    const isExcludedPotato =
       currStandard?.cultivation_rvo_table2.includes("pootaardappelen") ||
       currCult.b_lu_catalogue === "nl_2015" ||
       currCult.b_lu_catalogue === "nl_2016" ||
+      currCult.b_lu_catalogue === "nl_1911" ||
+      currCult.b_lu_catalogue === "nl_1912" ||
       currStandard?.cultivation_rvo_table2.includes("uitgroeiteelt")
 
     if (
       nonBouwlandCodes.includes(prevCult.b_lu_catalogue) &&
-      (isMaize || (isPotato && !isSeedPotato))
+      (isMaize || (isPotato && !isExcludedPotato))
     ) {
+      // Check Exclusion: Was previous grass a Catch Crop?
+      const isCatchCrop =
+        prevStandard?.is_vanggewas ||
+        (prevCult.b_lu_start &&
+          prevCult.b_lu_start.getFullYear() === previousYear &&
+          prevCult.b_lu_start.getMonth() >= 7) // August or later
+
+      if (isCatchCrop) {
+        continue
+      }
+
       const destructionDate = prevCult.b_lu_end
       let isValidDestruction = false
 
@@ -557,10 +503,6 @@ function calculateKorting(
           destructionDate <= new Date(currentYear, 4, 10) // May 10
         ) {
           isValidDestruction = true
-        } else {
-          throw new NormNotApplicableError(
-            "Graslandvernietiging op zand- en lössgrond is alleen toegestaan tussen 1 februari en 10 mei.",
-          )
         }
       } else if (clayOrPeatRegions.includes(region)) {
         if (is_nv_area) {
@@ -570,10 +512,6 @@ function calculateKorting(
             destructionDate <= new Date(currentYear, 2, 15)
           ) {
             isValidDestruction = true
-          } else {
-            throw new NormNotApplicableError(
-              "Graslandvernietiging op klei- en veengrond (NV-gebied) is alleen toegestaan tussen 1 februari en 15 maart.",
-            )
           }
         } else {
           // Clay/Peat Non-NV: Feb 1 - May 31
@@ -582,10 +520,6 @@ function calculateKorting(
             destructionDate <= new Date(currentYear, 4, 31)
           ) {
             isValidDestruction = true
-          } else {
-            throw new NormNotApplicableError(
-              "Graslandvernietiging op klei- en veengrond (niet NV-gebied) is alleen toegestaan tussen 1 februari en 31 mei.",
-            )
           }
         }
       }
@@ -611,105 +545,19 @@ function calculateKorting(
 }
 
 /**
- * Determines the 'gebruiksnorm' (usage standard) for nitrogen for a given cultivation
- * based on its BRP code, geographical location, and other specific characteristics.
- * This function is the primary entry point for calculating the nitrogen usage norm
- * according to the Dutch RVO's "Tabel 2 Stikstof landbouwgrond 2025" and related annexes.
- *
- * @param input - An object of type `NL2025NormsInput` containing all necessary data:
- *   - `farm.is_derogatie_bedrijf`: A boolean indicating if the farm operates under derogation.
- *   - `field.b_centroid`: An object with the latitude and longitude of the field's centroid.
- *   - `cultivations`: An array of cultivation objects, from which the `hoofdteelt` (main crop)
- *     will be determined.
- * @returns A promise that resolves to an object of type `GebruiksnormResult` containing:
- *   - `normValue`: The determined nitrogen usage standard in kilograms per hectare (kg/ha).
- *   - `normSource`: The descriptive name from RVO Table 2 used for the calculation.
- *   - `kortingDescription`: A description of any korting (reduction) applied to the norm.
- * Returns `null` if no matching standard or applicable norm can be found for the given input.
- * @throws {Error} If the `hoofdteelt` cultivation cannot be found or if geographical data
- *   queries fail.
- *
- * @remarks
- * The function follows a comprehensive, multi-step process to accurately determine the
- * correct nitrogen norm:
- *
- * 1.  **Identify Main Crop (`hoofdteelt`)**:
- *     The `findHoofdteelt` function is called to identify the primary cultivation
- *     (`b_lu_catalogue`) for the field based on the provided `cultivations` array. This is
- *     the first step to narrow down the applicable nitrogen standards.
- *
- * 2.  **Determine Geographical Context**:
- *     -   `isFieldInNVGebied`: This asynchronous helper function is called to check if the
- *         field's centroid falls within a Nitraatkwetsbaar Gebied (NV-gebied). Fields in NV-gebieds
- *         often have stricter (lower) nitrogen norms.
- *     -   `getRegion`: This asynchronous helper function determines the specific soil region
- *         (e.g., "zand" for sandy soil, "klei" for clay soil) based on the field's coordinates.
- *         Nitrogen norms can vary significantly by soil type.
- *     Both functions use efficient spatial queries to retrieve this information.
- *
- * 3.  **Match Nitrogen Standard Data**:
- *     The `nitrogenStandardsData` (loaded from a JSON file) is filtered to find all entries
- *     (`NitrogenStandard` objects) whose `b_lu_catalogue_match` array includes the identified
- *     `b_lu_catalogue` of the `hoofdteelt`.
- *
- * 4.  **Refine by Variety (for Potatoes)**:
- *     If the `hoofdteelt` has a specific `b_lu_variety` (e.g., for potatoes), the matching
- *     standards are further filtered. Potatoes can have "high" (`varieties_hoge_norm`) or
- *     "low" (`varieties_lage_norm`) nitrogen norms based on their variety. If a specific
- *     variety match is not found, it falls back to "overig" (other) potato norms if available.
- *
- * 5.  **Select the Most Specific Standard**:
- *     If multiple `NitrogenStandard` entries still match after initial filtering and
- *     variety-specific refinement, the function attempts to select the most specific one.
- *     This prioritization ensures that detailed rules (e.g., those without `variety_type`
- *     or `sub_types` if a direct match is found) are applied correctly.
- *
- * 6.  **Retrieve Applicable Norms**:
- *     The `getNormsForCultivation` helper function is called with the `selectedStandard`
- *     and other relevant parameters (variety, derogation status, cultivation end date).
- *     This function applies a hierarchy of rules (sub-type periods, variety-specific,
- *     derogation-specific) to return the precise `NormsByRegion` object for the cultivation.
- *
- * 7.  **Calculate Final Norm Value**:
- *     From the `applicableNorms` object, the function retrieves the specific norms for the
- *     determined `region`. The final `normValue` is then selected: if the field is in an
- *     `is_nv_area`, the `nv_area` norm is used; otherwise, the `standard` norm is applied.
- *
- * 8.  **Apply "Korting" (Reduction)**:
- *     The `calculateKorting` function is called to determine if a reduction should be applied
- *     based on the previous year's cultivations and the field's region. The calculated
- *     `kortingAmount` is then subtracted from the `normValue`.
- *
- * This detailed process ensures that the calculated nitrogen usage norm is accurate and
- * compliant with RVO regulations, taking into account all relevant agricultural and
- * geographical factors.
- *
- * @see {@link https://www.rvo.nl/sites/default/files/2024-12/Tabel-2-Stikstof-landbouwgrond-2025_0.pdf | RVO Tabel 2 Stikstof landbouwgrond 2025} - Official document for nitrogen norms.
- * @see {@link https://www.rvo.nl/onderwerpen/mest/gebruiken-en-uitrijden/stikstof-en-fosfaat/gebruiksnormen-stikstof | RVO Gebruiksnormen stikstof (official page)} - General information on nitrogen and phosphate norms.
+ * Calculates the nitrogen norm for a single cultivation in 2025.
  */
-export async function calculateNL2025StikstofGebruiksNorm(
-  input: NL2025NormsInput,
-): Promise<GebruiksnormResult> {
-  const is_derogatie_bedrijf = input.farm.is_derogatie_bedrijf
-  const has_grazing_intention = input.farm.has_grazing_intention
-  const field = input.field
-  const cultivations = input.cultivations
-
-  // Check for buffer strip
-  if (field.b_bufferstrip) {
-    return {
-      normValue: 0,
-      normSource: "Bufferstrook: geen plaatsingsruimte",
-    }
-  }
-
-  // Determine hoofdteelt
-  const cultivation = findHoofdteelt(cultivations, 2025, false, true)
+function calculateSingleCultivationNorm(
+  cultivation: NL2025NormsInputForCultivation,
+  isHoofdteelt: boolean,
+  prevCultivationsInYear: NL2025NormsInputForCultivation[],
+  cultivations: NL2025NormsInputForCultivation[],
+  is_derogatie_bedrijf: boolean | undefined,
+  has_grazing_intention: boolean | undefined,
+  region: RegionKey,
+  is_nv_area: boolean,
+): { normValue: Decimal; sourceName: string; subTypeText: string; noteText: string } {
   const b_lu_catalogue = cultivation.b_lu_catalogue
-
-  // Determine region and NV gebied
-  const is_nv_area = await isFieldInNVGebied(field.b_centroid)
-  const region = await getRegion(field.b_centroid)
 
   // Find matching nitrogen standard data based on b_lu_catalogue_match
   const matchingStandards: NitrogenStandard[] = nitrogenStandardsData.filter(
@@ -722,18 +570,33 @@ export async function calculateNL2025StikstofGebruiksNorm(
     )
   }
 
-  // Prioritize exact matches if multiple exist (e.g., for specific potato types)
+  // Prioritize exact matches if multiple exist (e.g., for volgteelt or specific potato types)
   let selectedStandard: NitrogenStandard | undefined
 
   if (matchingStandards.length === 1) {
     selectedStandard = matchingStandards[0]
   } else if (matchingStandards.length > 1) {
-    // If multiple standards match b_lu_catalogue, try to find a more specific one
-    // This could be based on sub_types with specific omschrijving or varieties
-    selectedStandard =
-      matchingStandards.find((ns) =>
-        ns.sub_types?.some((sub) => sub.omschrijving || sub.varieties),
-      ) || matchingStandards[0] // Fallback to the first if no specific sub_type is found
+    if (!isHoofdteelt) {
+      selectedStandard = matchingStandards.find((ns) =>
+        ns.cultivation_rvo_table2.toLowerCase().includes("volgteelt"),
+      )
+    } else {
+      selectedStandard =
+        matchingStandards.find(
+          (ns) =>
+            !ns.cultivation_rvo_table2.toLowerCase().includes("volgteelt") &&
+            ns.sub_types?.some((sub) => sub.omschrijving || sub.varieties),
+        ) ||
+        matchingStandards.find(
+          (ns) => !ns.cultivation_rvo_table2.toLowerCase().includes("volgteelt"),
+        )
+    }
+    if (!selectedStandard) {
+      selectedStandard =
+        matchingStandards.find((ns) =>
+          ns.sub_types?.some((sub) => sub.omschrijving || sub.varieties),
+        ) || matchingStandards[0]
+    }
   }
 
   if (!selectedStandard) {
@@ -751,6 +614,7 @@ export async function calculateNL2025StikstofGebruiksNorm(
     is_derogatie_bedrijf,
     cultivations,
     has_grazing_intention,
+    isHoofdteelt,
   )
 
   const applicableNorms = getNormsForCultivation(
@@ -775,6 +639,217 @@ export async function calculateNL2025StikstofGebruiksNorm(
   }
 
   let normValue = new Decimal(is_nv_area ? normsForRegion.nv_area : normsForRegion.standard)
+  let noteText = ""
+
+  // Footnote 2 & 6: Suppression of groenbemester, tijdelijk grasland and vanggewas norms after maize
+  const hasMaizeBefore =
+    !isHoofdteelt &&
+    prevCultivationsInYear.some(
+      (c) =>
+        maisCodes.includes(c.b_lu_catalogue) ||
+        nitrogenStandardsData
+          .find((ns) => ns.b_lu_catalogue_match.includes(c.b_lu_catalogue))
+          ?.cultivation_rvo_table2.toLowerCase()
+          .includes("mais"),
+    )
+
+  const isGroenbemesterOrCatchOrTempGrass =
+    selectedStandard.type === "groenbemester" ||
+    selectedStandard.is_vanggewas ||
+    selectedStandard.type === "grasland_tijdelijk" ||
+    tijdelijkGraslandCodes.includes(cultivation.b_lu_catalogue)
+
+  if (hasMaizeBefore && isGroenbemesterOrCatchOrTempGrass) {
+    normValue = new Decimal(0)
+    noteText = " (geen norm na maïs, voetnoot 2/6)"
+  } else if (selectedStandard.cultivation_rvo_table2 === "Groenbemesters, niet-vlinderbloemige") {
+    // Footnote 7a: Groenbemester conditions
+    const isSownBeforeSept1 =
+      cultivation.b_lu_start &&
+      (cultivation.b_lu_start.getFullYear() < 2025 ||
+        (cultivation.b_lu_start.getFullYear() === 2025 &&
+          (cultivation.b_lu_start.getMonth() < 8 ||
+            (cultivation.b_lu_start.getMonth() === 8 &&
+              cultivation.b_lu_start.getDate() === 1 &&
+              cultivation.b_lu_start.getHours() === 0))))
+
+    const isNotDestroyedBeforeFeb1 =
+      !cultivation.b_lu_end || cultivation.b_lu_end >= new Date(2026, 1, 1)
+
+    const immediatePrecedingCrop =
+      prevCultivationsInYear.length > 0
+        ? prevCultivationsInYear[prevCultivationsInYear.length - 1]
+        : undefined
+
+    const isPrecedingCerealOrRapeseedOrGrassSeed =
+      immediatePrecedingCrop &&
+      (graanCodes.includes(immediatePrecedingCrop.b_lu_catalogue) ||
+        koolzaadCodes.includes(immediatePrecedingCrop.b_lu_catalogue) ||
+        graszaadCodes.includes(immediatePrecedingCrop.b_lu_catalogue))
+
+    const isPrecedingGrasOpBouwland =
+      immediatePrecedingCrop &&
+      tijdelijkGraslandCodes.includes(immediatePrecedingCrop.b_lu_catalogue)
+
+    const isSandyOrLoess = ["zand_nwc", "zand_zuid", "loess"].includes(region)
+
+    if (!isSownBeforeSept1) {
+      normValue = new Decimal(0)
+      noteText = " (geen norm: gezaaid op of na 1 september, voetnoot 7a)"
+    } else if (!isNotDestroyedBeforeFeb1) {
+      normValue = new Decimal(0)
+      noteText = " (geen norm: vernietigd vóór 1 februari, voetnoot 7a)"
+    } else if (!immediatePrecedingCrop) {
+      normValue = new Decimal(0)
+      noteText = " (geen norm: geen voorafgaande teelt, voetnoot 7a)"
+    } else if (isPrecedingCerealOrRapeseedOrGrassSeed) {
+      // 100% of norm
+      noteText = " (volgteelt na granen, graszaad of koolzaad, voetnoot 7a)"
+    } else if (isSandyOrLoess && isPrecedingGrasOpBouwland) {
+      // 50% of norm on sand or loess after grass on arable land
+      normValue = normValue.dividedBy(2)
+      noteText = " (50% norm na gras op bouwland, voetnoot 7a)"
+    } else {
+      normValue = new Decimal(0)
+      noteText = " (geen norm: niet geteeld na granen, graszaad of koolzaad, voetnoot 7a)"
+    }
+  }
+
+  // Footnote 7b: Graszaadstoppel
+  if (
+    selectedStandard.cultivation_rvo_table2 ===
+    "Graszaadstoppel ter vernietiging in najaar of vroege voorjaar"
+  ) {
+    const isBeforeSept16 =
+      !cultivation.b_lu_start ||
+      cultivation.b_lu_start.getMonth() < 8 ||
+      (cultivation.b_lu_start.getMonth() === 8 && cultivation.b_lu_start.getDate() <= 16)
+
+    if (isBeforeSept16) {
+      noteText = " (graszaadstoppel, voetnoot 7b)"
+    } else {
+      normValue = new Decimal(0)
+      noteText = " (geen norm: niet voldaan aan voorwaarden graszaadstoppel, voetnoot 7b)"
+    }
+  }
+
+  // Grassland renewal: multiple grass crops on the same field in the same year share the annual grassland allowance
+  const isGrass = nonBouwlandCodes.includes(cultivation.b_lu_catalogue)
+  const hasGrassBeforeInYear = prevCultivationsInYear.some((c) =>
+    nonBouwlandCodes.includes(c.b_lu_catalogue),
+  )
+  if (!isHoofdteelt && isGrass && hasGrassBeforeInYear) {
+    normValue = new Decimal(0)
+    noteText = " (heringezaaid)"
+  }
+
+  const subTypeText = subTypeOmschrijving ? ` (${subTypeOmschrijving})` : ""
+  return {
+    normValue,
+    sourceName: selectedStandard.cultivation_rvo_table2,
+    subTypeText,
+    noteText,
+  }
+}
+
+/**
+ * Determines the 'gebruiksnorm' (usage standard) for nitrogen for a given cultivation plan in 2025
+ * by accumulating per-teelt norms across all crops in the calendar year according to
+ * Dutch RVO's "Tabel 2 Stikstof landbouwgrond 2025".
+ *
+ * @remarks
+ * See `fdm-docs/docs/insights/fertilizer-application-norms/nl/2025/stikstofgebruiksnorm.md` for full documentation
+ * of implemented rules, footnotes (2, 6, 7a, 7b, 14, 15, 16), and out-of-scope provisions.
+ */
+export async function calculateNL2025StikstofGebruiksNorm(
+  input: NL2025NormsInput,
+): Promise<GebruiksnormResult> {
+  const is_derogatie_bedrijf = input.farm.is_derogatie_bedrijf
+  const has_grazing_intention = input.farm.has_grazing_intention
+  const field = input.field
+  const cultivations = input.cultivations
+
+  // Check for buffer strip
+  if (field.b_bufferstrip) {
+    return {
+      normValue: 0,
+      normSource: "Bufferstrook: geen plaatsingsruimte",
+    }
+  }
+
+  // Determine region and NV gebied
+  const is_nv_area = await isFieldInNVGebied(field.b_centroid)
+  const region = await getRegion(field.b_centroid)
+
+  // Find hoofdteelt (May 15 - July 15)
+  const hoofdteelt = findHoofdteelt(cultivations, 2025, false, true)
+
+  // Filter cultivations active in 2025
+  const yearStart = new Date(2025, 0, 1)
+  const yearEnd = new Date(2025, 11, 31, 23, 59, 59, 999)
+
+  let yearCultivations = cultivations.filter((c) => {
+    // Must overlap with the norm year
+    const start = c.b_lu_start ? new Date(c.b_lu_start) : yearStart
+    const end = c.b_lu_end ? new Date(c.b_lu_end) : yearEnd
+    if (start > yearEnd || end < yearStart) return false
+
+    // If it started before the norm year, it is only included if it is the hoofdteelt of the norm year
+    if (c.b_lu_start && new Date(c.b_lu_start).getFullYear() < 2025) {
+      return c === hoofdteelt
+    }
+    // If it started after the norm year, it is not part of this year
+    if (c.b_lu_start && new Date(c.b_lu_start).getFullYear() > 2025) {
+      return false
+    }
+
+    return true
+  })
+
+  // If no cultivations active in 2025, use fallback hoofdteelt (groene braak)
+  if (yearCultivations.length === 0) {
+    yearCultivations = [hoofdteelt as NL2025NormsInputForCultivation]
+  }
+
+  // Sort chronologically by start date
+  const sortedCultivations = [...yearCultivations].sort((a, b) => {
+    const aTime = a.b_lu_start ? new Date(a.b_lu_start).getTime() : 0
+    const bTime = b.b_lu_start ? new Date(b.b_lu_start).getTime() : 0
+    return aTime - bTime
+  })
+
+  // Determine which index in sortedCultivations is the hoofdteelt
+  const hoofdteeltIndex = sortedCultivations.findIndex(
+    (c) => c.b_lu_catalogue === hoofdteelt.b_lu_catalogue,
+  )
+
+  let totalNormValue = new Decimal(0)
+  const normBreakdownItems: Array<{
+    sourceName: string
+    subTypeText: string
+    noteText: string
+    normValue: Decimal
+  }> = []
+
+  for (let i = 0; i < sortedCultivations.length; i++) {
+    const cult = sortedCultivations[i]
+    const isHoofd = hoofdteeltIndex !== -1 ? i === hoofdteeltIndex : i === 0
+    const prevCults = sortedCultivations.slice(0, i)
+
+    const result = calculateSingleCultivationNorm(
+      cult,
+      isHoofd,
+      prevCults,
+      cultivations,
+      is_derogatie_bedrijf,
+      has_grazing_intention,
+      region,
+      is_nv_area,
+    )
+
+    totalNormValue = totalNormValue.plus(result.normValue)
+    normBreakdownItems.push(result)
+  }
 
   // Apply korting
   const { amount: kortingAmount, description: kortingDescription } = calculateKorting(
@@ -783,31 +858,35 @@ export async function calculateNL2025StikstofGebruiksNorm(
     is_derogatie_bedrijf,
     is_nv_area,
   )
-  normValue = new Decimal(normValue).minus(kortingAmount)
+  let finalNormValue = totalNormValue.minus(kortingAmount)
 
   // If normvalue is negative, e.g. Geen plaatsingsruimte plus korting, set it to 0
-  if (normValue.isNegative()) {
-    normValue = new Decimal(0)
+  if (finalNormValue.isNegative()) {
+    finalNormValue = new Decimal(0)
   }
 
-  const subTypeText = subTypeOmschrijving ? ` (${subTypeOmschrijving})` : ""
+  let normSourceStr: string
+  if (normBreakdownItems.length === 1) {
+    const item = normBreakdownItems[0]
+    normSourceStr = `${item.sourceName}${item.subTypeText}${item.noteText}${kortingDescription}`
+  } else {
+    const breakdown = normBreakdownItems
+      .map(
+        (item) =>
+          `${item.sourceName}${item.subTypeText}${item.noteText} (${item.normValue.toNumber()} kg N/ha)`,
+      )
+      .join(" + ")
+    normSourceStr = `${breakdown}${kortingDescription}`
+  }
+
   return {
-    normValue: normValue.toNumber(),
-    normSource: `${selectedStandard.cultivation_rvo_table2}${subTypeText}${kortingDescription}`,
+    normValue: finalNormValue.toNumber(),
+    normSource: normSourceStr,
   }
 }
 
 /**
  * Memoized version of {@link calculateNL2025StikstofGebruiksNorm}.
- *
- * This function is wrapped with `withCalculationCache` to optimize performance by caching
- * results based on the input and the current calculator version.
- *
- * @param {NL2025NormsInput} input - An object of type `NL2025NormsInput` containing all necessary data.
- * @returns {Promise<GebruiksnormResult>} A promise that resolves to an object of type `GebruiksnormResult` containing:
- *   - `normValue`: The determined nitrogen usage standard in kilograms per hectare (kg/ha).
- *   - `normSource`: The descriptive name from RVO Table 2 used for the calculation.
- *   - `kortingDescription`: A description of any korting (reduction) applied to the norm.
  */
 export const getNL2025StikstofGebruiksNorm = withCalculationCache(
   calculateNL2025StikstofGebruiksNorm,

--- a/fdm-calculator/src/norms/nl/2025/value/vanggewas-winterteelt.test.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/vanggewas-winterteelt.test.ts
@@ -79,12 +79,17 @@ describe("Vanggewas & Winterteelt crop-code classification", () => {
       b_lu_start: new Date(2024, 5, 1), // Sown in June during maize
       b_lu_end: new Date(2025, 1, 1), // Stands until Feb 1
     }
-    expect(isWinterteelt("nl_316", 2025, maizeCultivation, [maizeCultivation, undersownCatchCrop])).toBe(true)
+    expect(
+      isWinterteelt("nl_316", 2025, maizeCultivation, [maizeCultivation, undersownCatchCrop]),
+    ).toBe(true)
 
     // With undersowing passed and missing b_lu_end on maize cultivation, returns true
     const maizeCultivationNoEnd = { b_lu_catalogue: "nl_316" }
     expect(
-      isWinterteelt("nl_316", 2025, maizeCultivationNoEnd, [maizeCultivationNoEnd, undersownCatchCrop]),
+      isWinterteelt("nl_316", 2025, maizeCultivationNoEnd, [
+        maizeCultivationNoEnd,
+        undersownCatchCrop,
+      ]),
     ).toBe(true)
   })
 

--- a/fdm-calculator/src/norms/nl/2026/filling/stikstofgebruiksnorm.test.ts
+++ b/fdm-calculator/src/norms/nl/2026/filling/stikstofgebruiksnorm.test.ts
@@ -548,7 +548,14 @@ describe("getWorkingCoefficient", () => {
   })
 
   it("should return default details when no subtype matches an entry with subtypes", () => {
-    const result = getWorkingCoefficient("46", undefined, false, true, new Date("2026-06-15"), false)
+    const result = getWorkingCoefficient(
+      "46",
+      undefined,
+      false,
+      true,
+      new Date("2026-06-15"),
+      false,
+    )
     expect(result.p_n_wcl).toBe(1)
     expect(result.description).toBe("Kunstmest")
   })

--- a/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm-data.ts
+++ b/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm-data.ts
@@ -692,21 +692,21 @@ export const nitrogenStandardsData = [
     },
   },
   {
-    cultivation_rvo_table2: "Akkerbouwgewassen,Veldbeemdgras",
+    cultivation_rvo_table2: "Akkerbouwgewassen, Veldbeemdgras",
     b_lu_catalogue_match: ["nl_1916", "nl_3523", "nl_6746", "nl_6788", "nl_6789"],
     type: "graszaad",
     is_winterteelt: true,
     is_vanggewas: true,
     norms: {
       klei: { standard: 130, nv_area: 104 },
-      zand_nwc: { standard: 110, nv_area: 80 },
-      zand_zuid: { standard: 100, nv_area: 64 },
+      zand_nwc: { standard: 100, nv_area: 80 },
+      zand_zuid: { standard: 80, nv_area: 64 },
       loess: { standard: 80, nv_area: 64 },
       veen: { standard: 105, nv_area: 84 },
     },
   },
   {
-    cultivation_rvo_table2: "Akkerbouwgewassen,Veldbeemdgras, volgteelt",
+    cultivation_rvo_table2: "Akkerbouwgewassen, Veldbeemdgras, volgteelt",
     b_lu_catalogue_match: ["nl_1916", "nl_3523", "nl_6746", "nl_6788", "nl_6789"],
     type: "graszaad",
     is_winterteelt: true,
@@ -778,7 +778,7 @@ export const nitrogenStandardsData = [
     ],
   },
   {
-    cultivation_rvo_table2: "Akkerbouwgewassen, Graszaad,Westerwolds",
+    cultivation_rvo_table2: "Akkerbouwgewassen, Graszaad, Westerwolds",
     b_lu_catalogue_match: ["nl_1919", "nl_3513", "nl_6790", "nl_6791"],
     type: "graszaad",
     is_winterteelt: true,
@@ -998,7 +998,7 @@ export const nitrogenStandardsData = [
     ],
   },
   {
-    cultivation_rvo_table2: "Baldgewassen, Spinazie volgteelt",
+    cultivation_rvo_table2: "Bladgewassen, Spinazie volgteelt",
     b_lu_catalogue_match: ["nl_1022"],
     type: "bladgewas",
     is_winterteelt: true,
@@ -1352,7 +1352,7 @@ export const nitrogenStandardsData = [
     ],
   },
   {
-    cultivation_rvo_table2: "Kruiden, bladgewas, eemalige oogst",
+    cultivation_rvo_table2: "Kruiden, bladgewas, eenmalige oogst",
     b_lu_catalogue_match: [
       "nl_1019",
       "nl_1020",
@@ -2020,7 +2020,7 @@ export const nitrogenStandardsData = [
     },
   },
   {
-    cultivation_rvo_table2: "Bloembollengewassen,Lelie",
+    cultivation_rvo_table2: "Bloembollengewassen, Lelie",
     b_lu_catalogue_match: ["nl_979", "nl_980", "nl_1002"],
     type: "bloembol",
     is_winterteelt: true,
@@ -2333,7 +2333,7 @@ export const nitrogenStandardsData = [
     },
   },
   {
-    cultivation_rvo_table2: "Boomkwekerijgewassen,Sierheesters",
+    cultivation_rvo_table2: "Boomkwekerijgewassen, Sierheesters",
     b_lu_catalogue_match: ["nl_1075"],
     type: "boomkwekerij",
     is_winterteelt: true,
@@ -2431,7 +2431,7 @@ export const nitrogenStandardsData = [
     },
   },
   {
-    cultivation_rvo_table2: "Boomkwekerijgewassen, Vruchtbomen, overig,",
+    cultivation_rvo_table2: "Boomkwekerijgewassen, Vruchtbomen, overig",
     b_lu_catalogue_match: ["nl_1079"],
     type: "boomkwekerij",
     is_winterteelt: true,
@@ -2532,6 +2532,8 @@ export const nitrogenStandardsData = [
   {
     cultivation_rvo_table2: "Geen plaatsingsruimte",
     b_lu_catalogue_match: [
+      "nl_332",
+      "nl_335",
       "nl_338",
       "nl_1940",
       "nl_2300",

--- a/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.test.ts
+++ b/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.test.ts
@@ -2073,4 +2073,190 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
     expect(result335.normValue).toBe(0)
     expect(result335.normSource).toContain("Geen plaatsingsruimte")
   })
+
+  it("resolves koolzaad subtype 'zomer' for nl_1923", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_1923", // Zomerkoolzaad
+          b_lu_start: new Date(2026, 2, 1),
+          b_lu_end: new Date(2026, 7, 1),
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+    expect(result.normSource).toContain("Akkerbouwgewassen, koolzaad (zomer)")
+  })
+
+  it("should grant 0 norm for groenbemester with footnote 7a when there is no preceding crop", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_428", // Groenbemester gele mosterd
+          b_lu_start: new Date(2026, 7, 15), // Aug 15, 2026 (< Sep 1)
+          b_lu_end: new Date(2027, 1, 15), // Feb 15, 2027 (>= Feb 1)
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+    expect(result.normValue).toBe(0)
+    expect(result.normSource).toContain(
+      "Groenbemesters, niet-vlinderbloemige (geen extra ruimte: geen voorafgaande teelt, voetnoot 7a)",
+    )
+  })
+
+  it("should evaluate Footnote 7b (Graszaadstoppel) before Sep 16 and on/after Sep 16", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const dataSpy = spyNitrogenStandards([
+      {
+        b_lu_catalogue_match: ["nl_graszaad_stoppel"],
+        cultivation_rvo_table2: "Graszaadstoppel ter vernietiging in najaar of vroege voorjaar",
+        type: "groenbemester",
+        norms: regionNorms(60),
+      } as unknown as NitrogenStandard,
+    ])
+
+    // Sown before Sep 16 (Sep 10) -> qualifies for norm
+    const inputBefore = baseInput([
+      {
+        b_lu_catalogue: "nl_graszaad_stoppel",
+        b_lu_start: new Date(2026, 8, 10),
+        b_lu_end: new Date(2027, 1, 1),
+      } as NL2026NormsInputForCultivation,
+    ])
+    const resultBefore = await calculateNL2026StikstofGebruiksNorm(inputBefore)
+    expect(resultBefore.normValue).toBe(60)
+    expect(resultBefore.normSource).toContain("(graszaadstoppel, voetnoot 7b)")
+
+    // Sown on or after Sep 16 (Sep 20) -> 0 norm
+    const inputAfter = baseInput([
+      {
+        b_lu_catalogue: "nl_graszaad_stoppel",
+        b_lu_start: new Date(2026, 8, 20),
+        b_lu_end: new Date(2027, 1, 1),
+      } as NL2026NormsInputForCultivation,
+    ])
+    const resultAfter = await calculateNL2026StikstofGebruiksNorm(inputAfter)
+    expect(resultAfter.normValue).toBe(0)
+    expect(resultAfter.normSource).toContain(
+      "(geen extra ruimte: niet voldaan aan voorwaarden graszaadstoppel, voetnoot 7b)",
+    )
+
+    dataSpy.mockRestore()
+  })
+
+  it("should filter out cultivations starting after the norm year", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_233", // Wintertarwe
+          b_lu_start: new Date(2026, 2, 1),
+          b_lu_end: new Date(2026, 7, 1),
+        },
+        {
+          b_lu_catalogue: "nl_233",
+          b_lu_start: new Date(2027, 2, 1), // Started after 2026
+          b_lu_end: new Date(2027, 7, 1),
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+    expect(result.normValue).toBe(245)
+    expect(result.normSource).toBe("Akkerbouwgewassen, wintertarwe.")
+  })
+
+  it("should fallback to groene braak when cultivations array is empty", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+    expect(result.normValue).toBe(0)
+    expect(result.normSource).toContain("Geen plaatsingsruimte")
+  })
+
+  it("should set norm 0 with (heringezaaid) for multiple grass crops in the same year", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
+    const mockInput: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_265", // Grasland
+          b_lu_start: new Date(2026, 2, 1),
+          b_lu_end: new Date(2026, 5, 1),
+        },
+        {
+          b_lu_catalogue: "nl_265", // Grasland herinzaai
+          b_lu_start: new Date(2026, 5, 2),
+          b_lu_end: new Date(2026, 9, 1),
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+    expect(result.normSource).toContain("(heringezaaid)")
+  })
+
+  it("should fallback to standard with subtypes when isVolgteelt is true but no volgteelt standard exists", async () => {
+    setupGeoMock(1, 0)
+    const dataSpy = spyNitrogenStandards([
+      {
+        b_lu_catalogue_match: ["nl_hoofd_only_2026"],
+        cultivation_rvo_table2: "Hoofdteelt gewas",
+        norms: regionNorms(95),
+        sub_types: [
+          {
+            omschrijving: "specifiek",
+            period_start_month: 1,
+            period_end_month: 12,
+            norms: regionNorms(95),
+          },
+        ],
+      } as unknown as NitrogenStandard,
+      {
+        b_lu_catalogue_match: ["nl_preceding_2026"],
+        cultivation_rvo_table2: "Preceding gewas",
+        norms: regionNorms(100),
+      } as unknown as NitrogenStandard,
+    ])
+
+    const result = await calculateNL2026StikstofGebruiksNorm(
+      baseInput([
+        {
+          b_lu_catalogue: "nl_preceding_2026",
+          b_lu_start: new Date(2026, 2, 1),
+          b_lu_end: new Date(2026, 5, 1),
+        } as NL2026NormsInputForCultivation,
+        {
+          b_lu_catalogue: "nl_hoofd_only_2026",
+          b_lu_start: new Date(2026, 5, 2),
+          b_lu_end: new Date(2026, 9, 1),
+        } as NL2026NormsInputForCultivation,
+      ]),
+    )
+
+    expect(result.normValue).toBe(195)
+    dataSpy.mockRestore()
+  })
 })

--- a/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.test.ts
+++ b/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.test.ts
@@ -1856,7 +1856,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
     const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
     expect(result.normValue).toBe(245)
     expect(result.normSource).toContain(
-      "Groenbemesters, niet-vlinderbloemige (geen norm: gezaaid op of na 1 september, voetnoot 7a) (0 kg N/ha)",
+      "Groenbemesters, niet-vlinderbloemige (geen extra ruimte: gezaaid op of na 1 september, voetnoot 7a) (0 kg N/ha)",
     )
   })
 
@@ -1882,7 +1882,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
     const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
     expect(result.normValue).toBe(245)
     expect(result.normSource).toContain(
-      "Groenbemesters, niet-vlinderbloemige (geen norm: vernietigd vóór 1 februari, voetnoot 7a) (0 kg N/ha)",
+      "Groenbemesters, niet-vlinderbloemige (geen extra ruimte: vernietigd vóór 1 februari, voetnoot 7a) (0 kg N/ha)",
     )
   })
 
@@ -1909,7 +1909,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
     // Tijdelijk grasland: 168 + Groenbemester 50% (40 * 0.5 = 20) = 188 kg N/ha
     expect(result.normValue).toBe(188)
     expect(result.normSource).toContain(
-      "Groenbemesters, niet-vlinderbloemige (50% norm na gras op bouwland, voetnoot 7a) (20 kg N/ha)",
+      "Groenbemesters, niet-vlinderbloemige (extra ruimte (50%) na gras op bouwland, voetnoot 7a) (20 kg N/ha)",
     )
   })
 
@@ -1989,7 +1989,33 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
     expect(result.normValue).toBe(185)
     expect(result.normSource).toContain("Akkerbouwgewassen, mais (185 kg N/ha)")
     expect(result.normSource).toContain(
-      "Groenbemesters, niet-vlinderbloemige (geen norm na maïs, voetnoot 2/6) (0 kg N/ha)",
+      "Groenbemesters, niet-vlinderbloemige (geen extra ruimte na maïs, voetnoot 2/6) (0 kg N/ha)",
+    )
+  })
+
+  it("should grant 0 norm with preceding crop explanation even if sown on or after 1 September", async () => {
+    const mockInput: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_2014", // Consumptieaardappelen (not cereals/rapeseed/grass seed)
+          b_lu_start: new Date(2026, 3, 1),
+          b_lu_end: new Date(2026, 7, 30),
+        },
+        {
+          b_lu_catalogue: "nl_428", // Groenbemester sown after 1 Sep following potatoes
+          b_lu_start: new Date(2026, 8, 5), // Sep 5, 2026
+          b_lu_end: new Date(2027, 1, 15),
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+    expect(result.normValue).toBe(250) // Potato norm only
+    expect(result.normSource).toContain(
+      "Groenbemesters, niet-vlinderbloemige (geen extra ruimte: niet geteeld na granen, graszaad of koolzaad, voetnoot 7a) (0 kg N/ha)",
     )
   })
 

--- a/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.test.ts
+++ b/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.test.ts
@@ -805,7 +805,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Korting Logic", () => {
       expect(result.normSource).toContain("Korting: 50kg N/ha: graslandvernieuwing")
     })
 
-    it("should throw error for invalid renewal date on Sand", async () => {
+    it("should not apply renewal korting for invalid renewal date on Sand", async () => {
       const mockInput: NL2026NormsInput = {
         farm: {
           has_grazing_intention: false,
@@ -818,7 +818,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Korting Logic", () => {
           {
             b_lu_catalogue: "nl_265", // Grass
             b_lu_start: new Date(2026, 0, 1),
-            b_lu_end: new Date(2026, 4, 15), // May 15 (Too early)
+            b_lu_end: new Date(2026, 4, 15), // May 15 (Too early, outside June 1 - Aug 31)
           },
           {
             b_lu_catalogue: "nl_265", // Grass
@@ -829,9 +829,9 @@ describe("calculateNL2026StikstofGebruiksNorm - Korting Logic", () => {
         soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
       }
 
-      await expect(calculateNL2026StikstofGebruiksNorm(mockInput)).rejects.toThrow(
-        "Graslandvernieuwing op zand- en lössgrond is alleen toegestaan tussen 1 juni en 31 augustus.",
-      )
+      const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+      expect(result.normSource).not.toContain("graslandvernieuwing")
+      expect(result.normValue).toBe(256)
     })
   })
 
@@ -1039,7 +1039,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Korting Logic", () => {
       expect(result.normSource).not.toContain("graslandvernietiging")
     })
 
-    it("should throw error for invalid destruction date on Sand", async () => {
+    it("should not apply destruction korting for invalid destruction date on Sand", async () => {
       const mockInput: NL2026NormsInput = {
         farm: {
           has_grazing_intention: false,
@@ -1063,9 +1063,9 @@ describe("calculateNL2026StikstofGebruiksNorm - Korting Logic", () => {
         soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
       }
 
-      await expect(calculateNL2026StikstofGebruiksNorm(mockInput)).rejects.toThrow(
-        "Graslandvernietiging op zand- en lössgrond is alleen toegestaan tussen 1 februari en 10 mei.",
-      )
+      const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+      expect(result.normSource).not.toContain("graslandvernietiging")
+      expect(result.normValue).toBe(368) // 256 + 112
     })
 
     it("should apply 65 discount on Sand (Consumption Potato, Feb 1 - May 10)", async () => {
@@ -1510,7 +1510,9 @@ describe("NL2026 stikstof additional branch coverage", () => {
         } as NL2026NormsInputForCultivation,
       ]),
     )
-    expect(winterui.normSource).toBe("Akkerbouwgewassen, Ui overig, zaaiui of winterui. (1e jaars).")
+    expect(winterui.normSource).toBe(
+      "Akkerbouwgewassen, Ui overig, zaaiui of winterui. (1e jaars).",
+    )
 
     const potatoNoVariety = await calculateNL2026StikstofGebruiksNorm(
       baseInput([
@@ -1646,11 +1648,11 @@ describe("NL2026 stikstof additional branch coverage", () => {
       ]),
     )
 
-    expect(result.normValue).toBe(180)
+    expect(result.normValue).toBe(540)
     dataSpy.mockRestore()
   })
 
-  it("throws for invalid clay renewal and destruction windows", async () => {
+  it("does not apply korting for invalid clay renewal and destruction windows", async () => {
     const dataSpy = spyNitrogenStandards([
       {
         b_lu_catalogue_match: ["nl_265"],
@@ -1667,40 +1669,38 @@ describe("NL2026 stikstof additional branch coverage", () => {
     ] as unknown as NitrogenStandard[])
 
     setupGeoMock(1, 0)
-    await expect(
-      calculateNL2026StikstofGebruiksNorm(
-        baseInput([
-          {
-            b_lu_catalogue: "nl_265",
-            b_lu_start: new Date(2026, 0, 1),
-            b_lu_end: new Date(2026, 10, 1),
-          } as NL2026NormsInputForCultivation,
-          {
-            b_lu_catalogue: "nl_265",
-            b_lu_start: new Date(2026, 10, 2),
-            b_lu_end: new Date(2026, 11, 31),
-          } as NL2026NormsInputForCultivation,
-        ]),
-      ),
-    ).rejects.toThrow("Graslandvernieuwing op klei- en veengrond is alleen toegestaan")
+    const renewalResult = await calculateNL2026StikstofGebruiksNorm(
+      baseInput([
+        {
+          b_lu_catalogue: "nl_265",
+          b_lu_start: new Date(2026, 0, 1),
+          b_lu_end: new Date(2026, 10, 1),
+        } as NL2026NormsInputForCultivation,
+        {
+          b_lu_catalogue: "nl_265",
+          b_lu_start: new Date(2026, 10, 2),
+          b_lu_end: new Date(2026, 11, 31),
+        } as NL2026NormsInputForCultivation,
+      ]),
+    )
+    expect(renewalResult.normSource).not.toContain("graslandvernieuwing")
 
     setupGeoMock(1, 0)
-    await expect(
-      calculateNL2026StikstofGebruiksNorm(
-        baseInput([
-          {
-            b_lu_catalogue: "nl_265",
-            b_lu_start: new Date(2025, 0, 1),
-            b_lu_end: new Date(2026, 5, 20),
-          } as NL2026NormsInputForCultivation,
-          {
-            b_lu_catalogue: "nl_maize_invalid_2026",
-            b_lu_start: new Date(2026, 6, 1),
-            b_lu_end: new Date(2026, 9, 1),
-          } as NL2026NormsInputForCultivation,
-        ]),
-      ),
-    ).rejects.toThrow("Graslandvernietiging op klei- en veengrond (niet NV-gebied)")
+    const destructionResult = await calculateNL2026StikstofGebruiksNorm(
+      baseInput([
+        {
+          b_lu_catalogue: "nl_265",
+          b_lu_start: new Date(2025, 0, 1),
+          b_lu_end: new Date(2026, 5, 20),
+        } as NL2026NormsInputForCultivation,
+        {
+          b_lu_catalogue: "nl_maize_invalid_2026",
+          b_lu_start: new Date(2026, 6, 1),
+          b_lu_end: new Date(2026, 9, 1),
+        } as NL2026NormsInputForCultivation,
+      ]),
+    )
+    expect(destructionResult.normSource).not.toContain("graslandvernietiging")
 
     dataSpy.mockRestore()
   })
@@ -1799,5 +1799,252 @@ describe("NL2026 stikstof additional branch coverage", () => {
 
     expect(result.normSource).toContain("Korting: 50kg N/ha: graslandvernieuwing")
     dataSpy.mockRestore()
+  })
+})
+
+describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests", () => {
+  const kleiCentroid: [number, number] = [5.64188724, 51.977587] // klei
+  const sandCentroid: [number, number] = [5.656346970245633, 51.987872886419524] // zand_nwc (NV)
+
+  it("should accumulate norms for wintertarwe + non-vlinderbloemige groenbemester (compliant dates)", async () => {
+    const mockInput: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: sandCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_233", // Wintertarwe (160 standard / 128 NV on zand_nwc)
+          b_lu_start: new Date(2025, 9, 15), // Oct 15, 2025 (hoofdteelt 2026)
+          b_lu_end: new Date(2026, 7, 10), // Aug 10, 2026
+        },
+        {
+          b_lu_catalogue: "nl_428", // Groenbemester gele mosterd (50 standard / 40 NV on zand_nwc)
+          b_lu_start: new Date(2026, 7, 15), // Aug 15, 2026 (< Sep 1)
+          b_lu_end: new Date(2027, 1, 15), // Feb 15, 2027 (>= Feb 1)
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+    // Wintertarwe: 128 (NV) + Groenbemester: 40 (NV) = 168 kg N/ha.
+    expect(result.normValue).toBe(168)
+    expect(result.normSource).toContain("Akkerbouwgewassen, wintertarwe (128 kg N/ha)")
+    expect(result.normSource).toContain(
+      "Groenbemesters, niet-vlinderbloemige (volgteelt na granen, graszaad of koolzaad, voetnoot 7a) (40 kg N/ha)",
+    )
+  })
+
+  it("should grant 0 norm for groenbemester if sown on or after 1 September (footnote 7a)", async () => {
+    const mockInput: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_233", // Wintertarwe (245 on klei)
+          b_lu_start: new Date(2025, 9, 15),
+          b_lu_end: new Date(2026, 7, 10),
+        },
+        {
+          b_lu_catalogue: "nl_428", // Groenbemester
+          b_lu_start: new Date(2026, 8, 2), // Sep 2, 2026 (>= Sep 1 -> 0 norm)
+          b_lu_end: new Date(2027, 1, 15),
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+    expect(result.normValue).toBe(245)
+    expect(result.normSource).toContain(
+      "Groenbemesters, niet-vlinderbloemige (geen norm: gezaaid op of na 1 september, voetnoot 7a) (0 kg N/ha)",
+    )
+  })
+
+  it("should grant 0 norm for groenbemester if destroyed before 1 February (footnote 7a)", async () => {
+    const mockInput: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_233", // Wintertarwe (245 on klei)
+          b_lu_start: new Date(2025, 9, 15),
+          b_lu_end: new Date(2026, 7, 10),
+        },
+        {
+          b_lu_catalogue: "nl_428", // Groenbemester
+          b_lu_start: new Date(2026, 7, 15), // Aug 15
+          b_lu_end: new Date(2026, 11, 1), // Dec 1, 2026 (< Feb 1, 2027 -> 0 norm)
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+    expect(result.normValue).toBe(245)
+    expect(result.normSource).toContain(
+      "Groenbemesters, niet-vlinderbloemige (geen norm: vernietigd vóór 1 februari, voetnoot 7a) (0 kg N/ha)",
+    )
+  })
+
+  it("should grant 50% groenbemester norm on sand after gras op bouwland (footnote 7a)", async () => {
+    const mockInput: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: sandCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_266", // Tijdelijk grasland (van 1 jan tot minstens 15 aug -> 168 NV)
+          b_lu_start: new Date(2026, 0, 1),
+          b_lu_end: new Date(2026, 7, 15),
+        },
+        {
+          b_lu_catalogue: "nl_428", // Groenbemester
+          b_lu_start: new Date(2026, 7, 16), // Aug 16 (< Sep 1)
+          b_lu_end: new Date(2027, 1, 15),
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+    // Tijdelijk grasland: 168 + Groenbemester 50% (40 * 0.5 = 20) = 188 kg N/ha
+    expect(result.normValue).toBe(188)
+    expect(result.normSource).toContain(
+      "Groenbemesters, niet-vlinderbloemige (50% norm na gras op bouwland, voetnoot 7a) (20 kg N/ha)",
+    )
+  })
+
+  it("should accumulate spinazie 1e teelt + spinazie volgteelt", async () => {
+    const mockInput: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_2773", // Spinazie 1e teelt (260 on klei)
+          b_lu_start: new Date(2026, 3, 1), // April 1
+          b_lu_end: new Date(2026, 5, 15), // June 15 (hoofdteelt)
+        },
+        {
+          b_lu_catalogue: "nl_2773", // Spinazie volgteelt (185 on klei)
+          b_lu_start: new Date(2026, 6, 1), // July 1
+          b_lu_end: new Date(2026, 8, 15), // Sep 15
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+    // 260 + 185 = 445 kg N/ha
+    expect(result.normValue).toBe(445)
+    expect(result.normSource).toContain("Bladgewassen, Spinazie (1e teelt) (260 kg N/ha)")
+    expect(result.normSource).toContain("Bladgewassen, Spinazie (volgteelt) (185 kg N/ha)")
+  })
+
+  it("should accumulate graszaad hoofdteelt + graszaad volgteelt", async () => {
+    const mockInput: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_1915", // Rietzwenkgras (140 on klei)
+          b_lu_start: new Date(2026, 0, 1),
+          b_lu_end: new Date(2026, 6, 31),
+        },
+        {
+          b_lu_catalogue: "nl_1915", // Rietzwenkgras volgteelt (60 on klei)
+          b_lu_start: new Date(2026, 7, 1),
+          b_lu_end: new Date(2026, 11, 31),
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+    // 140 + 60 = 200 kg N/ha
+    expect(result.normValue).toBe(200)
+    expect(result.normSource).toContain("Akkerbouwgewassen, Rietzwenkgras (140 kg N/ha)")
+    expect(result.normSource).toContain("Akkerbouwgewassen, Rietzwenkgras, volgteelt (60 kg N/ha)")
+  })
+
+  it("should grant 0 norm for groenbemester and tijdelijk grasland following maize (footnotes 2 & 6)", async () => {
+    const mockInput: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_259", // Mais (185 on klei)
+          b_lu_start: new Date(2026, 4, 1),
+          b_lu_end: new Date(2026, 8, 30),
+        },
+        {
+          b_lu_catalogue: "nl_428", // Groenbemester after maize
+          b_lu_start: new Date(2026, 9, 1),
+          b_lu_end: new Date(2027, 1, 15),
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+    // Mais 185 + Groenbemester 0 = 185 kg N/ha
+    expect(result.normValue).toBe(185)
+    expect(result.normSource).toContain("Akkerbouwgewassen, mais (185 kg N/ha)")
+    expect(result.normSource).toContain(
+      "Groenbemesters, niet-vlinderbloemige (geen norm na maïs, voetnoot 2/6) (0 kg N/ha)",
+    )
+  })
+
+  it("should return norm 0 for groene braak (nl_6794) under Geen plaatsingsruimte", async () => {
+    const mockInput: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_6794", // Groene braak
+          b_lu_start: new Date(2026, 4, 15),
+          b_lu_end: new Date(2026, 6, 15),
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result = await calculateNL2026StikstofGebruiksNorm(mockInput)
+    expect(result.normValue).toBe(0)
+    expect(result.normSource).toContain("Geen plaatsingsruimte")
+  })
+
+  it("should return norm 0 without throwing for nature codes nl_332 and nl_335", async () => {
+    const mockInput332: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_332", // natuurlijk grasland, hoofdfunctie natuur
+          b_lu_start: new Date(2026, 0, 1),
+          b_lu_end: new Date(2026, 11, 31),
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result332 = await calculateNL2026StikstofGebruiksNorm(mockInput332)
+    expect(result332.normValue).toBe(0)
+    expect(result332.normSource).toContain("Geen plaatsingsruimte")
+
+    const mockInput335: NL2026NormsInput = {
+      farm: { has_grazing_intention: false },
+      field: { b_id: "1", b_centroid: kleiCentroid } as Field,
+      cultivations: [
+        {
+          b_lu_catalogue: "nl_335", // natuurterreinen
+          b_lu_start: new Date(2026, 0, 1),
+          b_lu_end: new Date(2026, 11, 31),
+        },
+      ] as NL2026NormsInputForCultivation[],
+      soilAnalysis: { a_p_al: 20, a_p_cc: 0.9 },
+    }
+
+    const result335 = await calculateNL2026StikstofGebruiksNorm(mockInput335)
+    expect(result335.normValue).toBe(0)
+    expect(result335.normSource).toContain("Geen plaatsingsruimte")
   })
 })

--- a/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.test.ts
+++ b/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.test.ts
@@ -1803,10 +1803,15 @@ describe("NL2026 stikstof additional branch coverage", () => {
 })
 
 describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   const kleiCentroid: [number, number] = [5.64188724, 51.977587] // klei
   const sandCentroid: [number, number] = [5.656346970245633, 51.987872886419524] // zand_nwc (NV)
 
   it("should accumulate norms for wintertarwe + non-vlinderbloemige groenbemester (compliant dates)", async () => {
+    setupGeoMock(4, 1) // Sand, NV
     const mockInput: NL2026NormsInput = {
       farm: { has_grazing_intention: false },
       field: { b_id: "1", b_centroid: sandCentroid } as Field,
@@ -1835,6 +1840,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
   })
 
   it("should grant 0 norm for groenbemester if sown on or after 1 September (footnote 7a)", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
     const mockInput: NL2026NormsInput = {
       farm: { has_grazing_intention: false },
       field: { b_id: "1", b_centroid: kleiCentroid } as Field,
@@ -1861,6 +1867,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
   })
 
   it("should grant 0 norm for groenbemester if destroyed before 1 February (footnote 7a)", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
     const mockInput: NL2026NormsInput = {
       farm: { has_grazing_intention: false },
       field: { b_id: "1", b_centroid: kleiCentroid } as Field,
@@ -1887,6 +1894,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
   })
 
   it("should grant 50% groenbemester norm on sand after gras op bouwland (footnote 7a)", async () => {
+    setupGeoMock(4, 1) // Sand, NV
     const mockInput: NL2026NormsInput = {
       farm: { has_grazing_intention: false },
       field: { b_id: "1", b_centroid: sandCentroid } as Field,
@@ -1914,6 +1922,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
   })
 
   it("should accumulate spinazie 1e teelt + spinazie volgteelt", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
     const mockInput: NL2026NormsInput = {
       farm: { has_grazing_intention: false },
       field: { b_id: "1", b_centroid: kleiCentroid } as Field,
@@ -1940,6 +1949,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
   })
 
   it("should accumulate graszaad hoofdteelt + graszaad volgteelt", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
     const mockInput: NL2026NormsInput = {
       farm: { has_grazing_intention: false },
       field: { b_id: "1", b_centroid: kleiCentroid } as Field,
@@ -1966,6 +1976,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
   })
 
   it("should grant 0 norm for groenbemester and tijdelijk grasland following maize (footnotes 2 & 6)", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
     const mockInput: NL2026NormsInput = {
       farm: { has_grazing_intention: false },
       field: { b_id: "1", b_centroid: kleiCentroid } as Field,
@@ -1994,6 +2005,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
   })
 
   it("should grant 0 norm with preceding crop explanation even if sown on or after 1 September", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
     const mockInput: NL2026NormsInput = {
       farm: { has_grazing_intention: false },
       field: { b_id: "1", b_centroid: kleiCentroid } as Field,
@@ -2020,6 +2032,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
   })
 
   it("should return norm 0 for groene braak (nl_6794) under Geen plaatsingsruimte", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
     const mockInput: NL2026NormsInput = {
       farm: { has_grazing_intention: false },
       field: { b_id: "1", b_centroid: kleiCentroid } as Field,
@@ -2039,6 +2052,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
   })
 
   it("should return norm 0 without throwing for nature codes nl_332 and nl_335", async () => {
+    setupGeoMock(1, 0) // Clay, non-NV
     const mockInput332: NL2026NormsInput = {
       farm: { has_grazing_intention: false },
       field: { b_id: "1", b_centroid: kleiCentroid } as Field,
@@ -2221,6 +2235,11 @@ describe("calculateNL2026StikstofGebruiksNorm - Multi-Teelt & Compliance Tests",
   it("should fallback to standard with subtypes when isVolgteelt is true but no volgteelt standard exists", async () => {
     setupGeoMock(1, 0)
     const dataSpy = spyNitrogenStandards([
+      {
+        b_lu_catalogue_match: ["nl_hoofd_only_2026"],
+        cultivation_rvo_table2: "Gewas zonder subtypes",
+        norms: regionNorms(50),
+      } as unknown as NitrogenStandard,
       {
         b_lu_catalogue_match: ["nl_hoofd_only_2026"],
         cultivation_rvo_table2: "Hoofdteelt gewas",

--- a/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.test.ts
+++ b/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.test.ts
@@ -777,7 +777,7 @@ describe("calculateNL2026StikstofGebruiksNorm - Korting Logic", () => {
       expect(result.normSource).toContain("Korting: 50kg N/ha: graslandvernieuwing")
     })
 
-    it("should apply 50 discount on Clay (Feb 1 - Sep 15)", async () => {
+    it("should apply 50 discount on Clay (June 1 - Aug 31)", async () => {
       const mockInput: NL2026NormsInput = {
         farm: {
           has_grazing_intention: false,

--- a/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.ts
+++ b/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.ts
@@ -13,45 +13,18 @@ import pkg from "../../../../package"
 import { findHoofdteelt } from "../../../../shared/hoofdteelt"
 import { getRegion, isFieldInNVGebied } from "../../2025/value/stikstofgebruiksnorm"
 import { calculateVanggewasWinterteeltKorting } from "../../2025/value/vanggewas-winterteelt"
-import { nonBouwlandCodes } from "../../constant"
+import {
+  graanCodes,
+  graszaadCodes,
+  koolzaadCodes,
+  maisCodes,
+  nonBouwlandCodes,
+  tijdelijkGraslandCodes,
+} from "../../constant"
 import { nitrogenStandardsData } from "./stikstofgebruiksnorm-data"
 
 /**
  * Retrieves the appropriate set of nitrogen norms (`NormsByRegion`) for a given cultivation.
- * This function applies a set of specific rules and conditions to select the most accurate
- * norm from the available `NitrogenStandard` data, considering factors like cultivation
- * sub-types, specific varieties, and farm derogation status.
- *
- * @param selectedStandard - The base `NitrogenStandard` object that broadly matches the cultivation.
- *   This object contains various norm categories (e.g., general, sub-type specific, variety-specific).
- * @param b_lu_variety - Optional. The specific variety of the cultivation (e.g., a potato variety).
- *   This is used to apply variety-specific norms where applicable.
- * @param b_lu_end - The termination date of the cultivation. This is crucial for determining
- *   applicable sub-type periods, especially for temporary grasslands where norms can vary
- *   based on the period of the year.
- * @returns A `NormsByRegion` object containing standard and NV-gebied norms for all regions
- *   (e.g., "zand_nwc", "zand_zuid", "klei", "veen", "loess") that apply to the specific cultivation and conditions.
- *   Returns `undefined` if no applicable norms can be found based on the provided criteria.
- *
- * @remarks
- * The function prioritizes norm selection based on the following hierarchy:
- * 1.  **Sub-Type Norms (e.g., Temporary Grasslands)**:
- *     If `selectedStandard` has `sub_types` defined (e.g., for temporary grasslands),
- *     it checks if the `b_lu_end` date falls within any of the specified `period_start_month`
- *     and `period_end_month` ranges. If a matching sub-type period is found, its associated
- *     norms are returned. This ensures that time-sensitive norms are correctly applied.
- * 2.  **Variety-Specific Norms (e.g., Potatoes)**:
- *     If the `selectedStandard` is for "aardappel" (potato) and `b_lu_variety` is provided,
- *     the function checks if the variety matches any in `varieties_hoge_norm` (high norms)
- *     or `varieties_lage_norm` (low norms). If a match is found, the corresponding norms
- *     (`norms_hoge_norm` or `norms_lage_norm`) are returned. If the variety doesn't match
- *     these specific lists, it falls back to `norms_overig` (other) potato norms if available.
- * 4.  **Default Norms**:
- *     If none of the above specific conditions are met, the function defaults to returning
- *     the primary `norms` defined directly within the `selectedStandard` object.
- *
- * This structured approach ensures that the most specific and applicable nitrogen norm
- * is always retrieved for the given cultivation context.
  */
 function getNormsForCultivation(
   selectedStandard: NitrogenStandard,
@@ -119,13 +92,14 @@ function getNormsForCultivation(
           sub.period_start_month > 1
 
         if (isVanaf) {
-          // If it's a "tot minstens" period (implied by end month < 12), it must also last until endPeriod.
+          // If it's a "tot minstens" period (implied by end month < 12), it must also last until endPeriod,
+          // and the crop must have been sown on or before endPeriod (cannot start after the period has ended).
           if (
             sub.period_end_month !== null &&
             sub.period_end_month !== undefined &&
             sub.period_end_month < 12
           ) {
-            return startDate >= startPeriod && endDate >= endPeriod
+            return startDate >= startPeriod && startDate <= endPeriod && endDate >= endPeriod
           }
           // For "vanaf X" (without "tot minstens", e.g. "vanaf 15 oktober"), we only check if it starts on or after X.
           return startDate >= startPeriod
@@ -201,18 +175,13 @@ function getNormsForCultivation(
 
 /**
  * Determines the specific sub-type 'omschrijving' for a cultivation that is part of a larger group.
- * This is necessary for standards that use sub_types to differentiate norms, e.g., for winter vs. summer varieties.
- *
- * @param cultivation - The specific cultivation for which to determine the sub-type.
- * @param standard - The matched NitrogenStandard which may contain sub_types.
- * @param cultivations - An array of cultivation objects for the current and previous year.
- * @returns The 'omschrijving' of the matching sub-type as a string, or undefined if no specific sub-type applies.
  */
 function determineSubTypeOmschrijving(
   cultivation: NL2026NormsInputForCultivation,
   standard: NitrogenStandard,
   cultivations: NL2026NormsInputForCultivation[],
   has_grazing_intention: boolean | undefined,
+  isHoofdteelt: boolean = true,
 ): string | undefined {
   // Grasland logic based on grazing intention
   if (standard.type === "grasland") {
@@ -303,7 +272,7 @@ function determineSubTypeOmschrijving(
     if (cultivation.b_lu_catalogue === "nl_1933") return "2e jaars"
   }
 
-  // Bladgewassen logic based on hoofdteelt
+  // Bladgewassen logic based on hoofdteelt vs volgteelt
   const bladgewasRvoTable2s = [
     "Bladgewassen, Spinazie",
     "Bladgewassen, Slasoorten",
@@ -311,21 +280,8 @@ function determineSubTypeOmschrijving(
   ]
 
   if (bladgewasRvoTable2s.includes(standard.cultivation_rvo_table2)) {
-    const hoofdteeltCatalogue = findHoofdteelt(cultivations, 2026, false, true).b_lu_catalogue
-    if (cultivation.b_lu_catalogue === hoofdteeltCatalogue) {
-      return "1e teelt"
-    }
-    // TODO: Implement volgteelt logic here later
+    return isHoofdteelt ? "1e teelt" : "volgteelt"
   }
-
-  /*
-   * --- Cultivations with Unclear Differentiation Logic (may require matching on b_lu string or external context): ---
-   * - Bladgewassen, Bladgewassen overig (e.g., "eenmalige oogst" vs. "meermalige oogst")
-   * - Kruiden (differentiating between bladgewas, wortelgewassen, zaadgewassen)
-   * - Bloembollengewassen, Iris (e.g., "grofbollig" vs. "fijnbollig")
-   * - Bloembollengewassen, Krokus (e.g., "grote gele" vs. "overig")
-   * - Bloembollengewassen, Gladiool (e.g., "pitten" vs. "kralen")
-   */
 
   return undefined
 }
@@ -333,10 +289,6 @@ function determineSubTypeOmschrijving(
 /**
  * Calculates the "korting" (reduction) on the nitrogen usage norm based on the presence
  * of winter crops or catch crops in the previous year.
- *
- * @param cultivations - An array of cultivation objects for the current and previous year.
- * @param region - The soil region of the field (e.g., "zand_nwc", "zand_zuid", "loess").
- * @returns An object containing the reduction amount in kilograms of nitrogen per hectare (kg N/ha) and a description.
  */
 function calculateKorting(
   cultivations: NL2026NormsInputForCultivation[],
@@ -383,30 +335,13 @@ function calculateKorting(
       const renewalDate = prevCult.b_lu_end
       let isValidRenewal = false
 
-      if (sandyOrLoessRegions.includes(region)) {
-        // Sand/Loess: June 1 - August 31
-        if (
-          renewalDate >= new Date(currentYear, 5, 1) && // June 1
-          renewalDate <= new Date(currentYear, 7, 31) // Aug 31
-        ) {
-          isValidRenewal = true
-        } else {
-          throw new NormNotApplicableError(
-            "Graslandvernieuwing op zand- en lössgrond is alleen toegestaan tussen 1 juni en 31 augustus.",
-          )
-        }
-      } else if (clayOrPeatRegions.includes(region)) {
-        // Non-Derogation in 2026: February 1 - September 15
-        if (
-          renewalDate >= new Date(currentYear, 1, 1) &&
-          renewalDate <= new Date(currentYear, 8, 15)
-        ) {
-          isValidRenewal = true
-        } else {
-          throw new NormNotApplicableError(
-            "Graslandvernieuwing op klei- en veengrond is alleen toegestaan tussen 1 februari en 15 september.",
-          )
-        }
+      // Footnote 14 (2026): Renewal between 1 June and 31 August for all soil types
+      const isJuneToAugust =
+        renewalDate >= new Date(currentYear, 5, 1) && // June 1
+        renewalDate <= new Date(currentYear, 7, 31) // Aug 31
+
+      if (isJuneToAugust) {
+        isValidRenewal = true
       }
 
       if (isValidRenewal) {
@@ -418,13 +353,15 @@ function calculateKorting(
     // 2. Grassland Destruction (Gras-naar-Bouwland) -> 65 kg N/ha korting
     const isMaize = currStandard?.cultivation_rvo_table2.includes("mais")
     const isPotato = currStandard?.type === "aardappel"
-    const isSeedPotato =
+    const isExcludedPotato =
       currStandard?.cultivation_rvo_table2.includes("pootaardappelen") ||
       currCult.b_lu_catalogue === "nl_2015" ||
       currCult.b_lu_catalogue === "nl_2016" ||
+      currCult.b_lu_catalogue === "nl_1911" ||
+      currCult.b_lu_catalogue === "nl_1912" ||
       currStandard?.cultivation_rvo_table2.includes("uitgroeiteelt")
 
-    if (isPrevGrass && (isMaize || (isPotato && !isSeedPotato))) {
+    if (isPrevGrass && (isMaize || (isPotato && !isExcludedPotato))) {
       // Check Exclusion: Was previous grass a Catch Crop?
       const isCatchCrop =
         prevStandard?.is_vanggewas ||
@@ -446,10 +383,6 @@ function calculateKorting(
           destructionDate <= new Date(currentYear, 4, 10) // May 10
         ) {
           isValidDestruction = true
-        } else {
-          throw new NormNotApplicableError(
-            "Graslandvernietiging op zand- en lössgrond is alleen toegestaan tussen 1 februari en 10 mei.",
-          )
         }
       } else if (clayOrPeatRegions.includes(region)) {
         if (is_nv_area) {
@@ -459,10 +392,6 @@ function calculateKorting(
             destructionDate <= new Date(currentYear, 2, 15)
           ) {
             isValidDestruction = true
-          } else {
-            throw new NormNotApplicableError(
-              "Graslandvernietiging op klei- en veengrond (NV-gebied) is alleen toegestaan tussen 1 februari en 15 maart.",
-            )
           }
         } else {
           // Clay/Peat Non-NV: Feb 1 - May 31
@@ -471,10 +400,6 @@ function calculateKorting(
             destructionDate <= new Date(currentYear, 4, 31)
           ) {
             isValidDestruction = true
-          } else {
-            throw new NormNotApplicableError(
-              "Graslandvernietiging op klei- en veengrond (niet NV-gebied) is alleen toegestaan tussen 1 februari en 31 mei.",
-            )
           }
         }
       }
@@ -500,104 +425,18 @@ function calculateKorting(
 }
 
 /**
- * Determines the 'gebruiksnorm' (usage standard) for nitrogen for a given cultivation
- * based on its BRP code, geographical location, and other specific characteristics.
- * This function is the primary entry point for calculating the nitrogen usage norm
- * according to the Dutch RVO's "Tabel 2 Stikstof landbouwgrond 2026" and related annexes.
- *
- * @param input - An object of type `NL2026NormsInput` containing all necessary data:
- *   - `farm.is_derogatie_bedrijf`: A boolean indicating if the farm operates under derogation.
- *   - `field.b_centroid`: An object with the latitude and longitude of the field's centroid.
- *   - `cultivations`: An array of cultivation objects, from which the `hoofdteelt` (main crop)
- *     will be determined.
- * @returns A promise that resolves to an object of type `GebruiksnormResult` containing:
- *   - `normValue`: The determined nitrogen usage standard in kilograms per hectare (kg/ha).
- *   - `normSource`: The descriptive name from RVO Table 2 used for the calculation.
- *   - `kortingDescription`: A description of any korting (reduction) applied to the norm.
- * Returns `null` if no matching standard or applicable norm can be found for the given input.
- * @throws {Error} If the `hoofdteelt` cultivation cannot be found or if geographical data
- *   queries fail.
- *
- * @remarks
- * The function follows a comprehensive, multi-step process to accurately determine the
- * correct nitrogen norm:
- *
- * 1.  **Identify Main Crop (`hoofdteelt`)**:
- *     The `findHoofdteelt` function is called to identify the primary cultivation
- *     (`b_lu_catalogue`) for the field based on the provided `cultivations` array. This is
- *     the first step to narrow down the applicable nitrogen standards.
- *
- * 2.  **Determine Geographical Context**:
- *     -   `isFieldInNVGebied`: This asynchronous helper function is called to check if the
- *         field's centroid falls within a Nitraatkwetsbaar Gebied (NV-gebied). Fields in NV-gebieds
- *         often have stricter (lower) nitrogen norms.
- *     -   `getRegion`: This asynchronous helper function determines the specific soil region
- *         (e.g., "zand" for sandy soil, "klei" for clay soil) based on the field's coordinates.
- *         Nitrogen norms can vary significantly by soil type.
- *     Both functions use efficient spatial queries to retrieve this information.
- *
- * 3.  **Match Nitrogen Standard Data**:
- *     The `nitrogenStandardsData` (loaded from a JSON file) is filtered to find all entries
- *     (`NitrogenStandard` objects) whose `b_lu_catalogue_match` array includes the identified
- *     `b_lu_catalogue` of the `hoofdteelt`.
- *
- * 4.  **Refine by Variety (for Potatoes)**:
- *     If the `hoofdteelt` has a specific `b_lu_variety` (e.g., for potatoes), the matching
- *     standards are further filtered. Potatoes can have "high" (`varieties_hoge_norm`) or
- *     "low" (`varieties_lage_norm`) nitrogen norms based on their variety. If a specific
- *     variety match is not found, it falls back to "overig" (other) potato norms if available.
- *
- * 5.  **Select the Most Specific Standard**:
- *     If multiple `NitrogenStandard` entries still match after initial filtering and
- *     variety-specific refinement, the function attempts to select the most specific one.
- *     This prioritization ensures that detailed rules (e.g., those without `variety_type`
- *     or `sub_types` if a direct match is found) are applied correctly.
- *
- * 6.  **Retrieve Applicable Norms**:
- *     The `getNormsForCultivation` helper function is called with the `selectedStandard`
- *     and other relevant parameters (variety, cultivation end date).
- *     This function applies a hierarchy of rules (sub-type periods, variety-specific,
- *     derogation-specific) to return the precise `NormsByRegion` object for the cultivation.
- *
- * 7.  **Calculate Final Norm Value**:
- *     From the `applicableNorms` object, the function retrieves the specific norms for the
- *     determined `region`. The final `normValue` is then selected: if the field is in an
- *     `is_nv_area`, the `nv_area` norm is used; otherwise, the `standard` norm is applied.
- *
- * 8.  **Apply "Korting" (Reduction)**:
- *     The `calculateKorting` function is called to determine if a reduction should be applied
- *     based on the previous year's cultivations and the field's region. The calculated
- *     `kortingAmount` is then subtracted from the `normValue`.
- *
- * This detailed process ensures that the calculated nitrogen usage norm is accurate and
- * compliant with RVO regulations, taking into account all relevant agricultural and
- * geographical factors.
- *
- * @see {@link https://www.rvo.nl/sites/default/files/2025-12/Tabel-2-Stikstof-landbouwgrond-2026_0.pdf | RVO Tabel 2 Stikstof landbouwgrond 2026} - Official document for nitrogen norms.
- * @see {@link https://www.rvo.nl/onderwerpen/mest/gebruiken-en-uitrijden/stikstof-en-fosfaat/gebruiksnormen-stikstof | RVO Gebruiksnormen stikstof (official page)} - General information on nitrogen and phosphate norms.
+ * Calculates the nitrogen norm for a single cultivation in 2026.
  */
-export async function calculateNL2026StikstofGebruiksNorm(
-  input: NL2026NormsInput,
-): Promise<GebruiksnormResult> {
-  const has_grazing_intention = input.farm.has_grazing_intention
-  const field = input.field
-  const cultivations = input.cultivations
-
-  // Check for buffer strip
-  if (field.b_bufferstrip) {
-    return {
-      normValue: 0,
-      normSource: "Bufferstrook: geen plaatsingsruimte",
-    }
-  }
-
-  // Determine hoofdteelt
-  const cultivation = findHoofdteelt(cultivations, 2026, false, true)
+function calculateSingleCultivationNorm(
+  cultivation: NL2026NormsInputForCultivation,
+  isHoofdteelt: boolean,
+  prevCultivationsInYear: NL2026NormsInputForCultivation[],
+  cultivations: NL2026NormsInputForCultivation[],
+  has_grazing_intention: boolean | undefined,
+  region: RegionKey,
+  is_nv_area: boolean,
+): { normValue: Decimal; sourceName: string; subTypeText: string; noteText: string } {
   const b_lu_catalogue = cultivation.b_lu_catalogue
-
-  // Determine region and NV gebied
-  const is_nv_area = await isFieldInNVGebied(field.b_centroid)
-  const region = await getRegion(field.b_centroid)
 
   // Find matching nitrogen standard data based on b_lu_catalogue_match
   const matchingStandards: NitrogenStandard[] = nitrogenStandardsData.filter(
@@ -610,18 +449,33 @@ export async function calculateNL2026StikstofGebruiksNorm(
     )
   }
 
-  // Prioritize exact matches if multiple exist (e.g., for specific potato types)
+  // Prioritize exact matches if multiple exist (e.g., for volgteelt or specific potato types)
   let selectedStandard: NitrogenStandard | undefined
 
   if (matchingStandards.length === 1) {
     selectedStandard = matchingStandards[0]
   } else if (matchingStandards.length > 1) {
-    // If multiple standards match b_lu_catalogue, try to find a more specific one
-    // This could be based on sub_types with specific omschrijving or varieties
-    selectedStandard =
-      matchingStandards.find((ns) =>
-        ns.sub_types?.some((sub) => sub.omschrijving || sub.varieties),
-      ) || matchingStandards[0] // Fallback to the first if no specific sub_type is found
+    if (!isHoofdteelt) {
+      selectedStandard = matchingStandards.find((ns) =>
+        ns.cultivation_rvo_table2.toLowerCase().includes("volgteelt"),
+      )
+    } else {
+      selectedStandard =
+        matchingStandards.find(
+          (ns) =>
+            !ns.cultivation_rvo_table2.toLowerCase().includes("volgteelt") &&
+            ns.sub_types?.some((sub) => sub.omschrijving || sub.varieties),
+        ) ||
+        matchingStandards.find(
+          (ns) => !ns.cultivation_rvo_table2.toLowerCase().includes("volgteelt"),
+        )
+    }
+    if (!selectedStandard) {
+      selectedStandard =
+        matchingStandards.find((ns) =>
+          ns.sub_types?.some((sub) => sub.omschrijving || sub.varieties),
+        ) || matchingStandards[0]
+    }
   }
 
   if (!selectedStandard) {
@@ -638,6 +492,7 @@ export async function calculateNL2026StikstofGebruiksNorm(
     selectedStandard,
     cultivations,
     has_grazing_intention,
+    isHoofdteelt,
   )
 
   const applicableNorms = getNormsForCultivation(
@@ -662,6 +517,215 @@ export async function calculateNL2026StikstofGebruiksNorm(
   }
 
   let normValue = new Decimal(is_nv_area ? normsForRegion.nv_area : normsForRegion.standard)
+  let noteText = ""
+
+  // Footnote 2 & 6: Suppression of groenbemester, tijdelijk grasland and vanggewas norms after maize
+  const hasMaizeBefore =
+    !isHoofdteelt &&
+    prevCultivationsInYear.some(
+      (c) =>
+        maisCodes.includes(c.b_lu_catalogue) ||
+        nitrogenStandardsData
+          .find((ns) => ns.b_lu_catalogue_match.includes(c.b_lu_catalogue))
+          ?.cultivation_rvo_table2.toLowerCase()
+          .includes("mais"),
+    )
+
+  const isGroenbemesterOrCatchOrTempGrass =
+    selectedStandard.type === "groenbemester" ||
+    selectedStandard.is_vanggewas ||
+    selectedStandard.type === "grasland_tijdelijk" ||
+    tijdelijkGraslandCodes.includes(cultivation.b_lu_catalogue)
+
+  if (hasMaizeBefore && isGroenbemesterOrCatchOrTempGrass) {
+    normValue = new Decimal(0)
+    noteText = " (geen norm na maïs, voetnoot 2/6)"
+  } else if (selectedStandard.cultivation_rvo_table2 === "Groenbemesters, niet-vlinderbloemige") {
+    // Footnote 7a: Groenbemester conditions
+    const isSownBeforeSept1 =
+      cultivation.b_lu_start &&
+      (cultivation.b_lu_start.getFullYear() < 2026 ||
+        (cultivation.b_lu_start.getFullYear() === 2026 &&
+          (cultivation.b_lu_start.getMonth() < 8 ||
+            (cultivation.b_lu_start.getMonth() === 8 &&
+              cultivation.b_lu_start.getDate() === 1 &&
+              cultivation.b_lu_start.getHours() === 0))))
+
+    const isNotDestroyedBeforeFeb1 =
+      !cultivation.b_lu_end || cultivation.b_lu_end >= new Date(2027, 1, 1)
+
+    const immediatePrecedingCrop =
+      prevCultivationsInYear.length > 0
+        ? prevCultivationsInYear[prevCultivationsInYear.length - 1]
+        : undefined
+
+    const isPrecedingCerealOrRapeseedOrGrassSeed =
+      immediatePrecedingCrop &&
+      (graanCodes.includes(immediatePrecedingCrop.b_lu_catalogue) ||
+        koolzaadCodes.includes(immediatePrecedingCrop.b_lu_catalogue) ||
+        graszaadCodes.includes(immediatePrecedingCrop.b_lu_catalogue))
+
+    const isPrecedingGrasOpBouwland =
+      immediatePrecedingCrop &&
+      tijdelijkGraslandCodes.includes(immediatePrecedingCrop.b_lu_catalogue)
+
+    const isSandyOrLoess = ["zand_nwc", "zand_zuid", "loess"].includes(region)
+
+    if (!isSownBeforeSept1) {
+      normValue = new Decimal(0)
+      noteText = " (geen norm: gezaaid op of na 1 september, voetnoot 7a)"
+    } else if (!isNotDestroyedBeforeFeb1) {
+      normValue = new Decimal(0)
+      noteText = " (geen norm: vernietigd vóór 1 februari, voetnoot 7a)"
+    } else if (!immediatePrecedingCrop) {
+      normValue = new Decimal(0)
+      noteText = " (geen norm: geen voorafgaande teelt, voetnoot 7a)"
+    } else if (isPrecedingCerealOrRapeseedOrGrassSeed) {
+      // 100% of norm
+      noteText = " (volgteelt na granen, graszaad of koolzaad, voetnoot 7a)"
+    } else if (isSandyOrLoess && isPrecedingGrasOpBouwland) {
+      // 50% of norm on sand or loess after grass on arable land
+      normValue = normValue.dividedBy(2)
+      noteText = " (50% norm na gras op bouwland, voetnoot 7a)"
+    } else {
+      normValue = new Decimal(0)
+      noteText = " (geen norm: niet geteeld na granen, graszaad of koolzaad, voetnoot 7a)"
+    }
+  }
+
+  // Footnote 7b: Graszaadstoppel
+  if (
+    selectedStandard.cultivation_rvo_table2 ===
+    "Graszaadstoppel ter vernietiging in najaar of vroege voorjaar"
+  ) {
+    const isBeforeSept16 =
+      !cultivation.b_lu_start ||
+      cultivation.b_lu_start.getMonth() < 8 ||
+      (cultivation.b_lu_start.getMonth() === 8 && cultivation.b_lu_start.getDate() <= 16)
+
+    if (isBeforeSept16) {
+      noteText = " (graszaadstoppel, voetnoot 7b)"
+    } else {
+      normValue = new Decimal(0)
+      noteText = " (geen norm: niet voldaan aan voorwaarden graszaadstoppel, voetnoot 7b)"
+    }
+  }
+
+  // Grassland renewal: multiple grass crops on the same field in the same year share the annual grassland allowance
+  const isGrass = nonBouwlandCodes.includes(cultivation.b_lu_catalogue)
+  const hasGrassBeforeInYear = prevCultivationsInYear.some((c) =>
+    nonBouwlandCodes.includes(c.b_lu_catalogue),
+  )
+  if (!isHoofdteelt && isGrass && hasGrassBeforeInYear) {
+    normValue = new Decimal(0)
+    noteText = " (heringezaaid)"
+  }
+
+  const subTypeText = subTypeOmschrijving ? ` (${subTypeOmschrijving})` : ""
+  return {
+    normValue,
+    sourceName: selectedStandard.cultivation_rvo_table2,
+    subTypeText,
+    noteText,
+  }
+}
+
+/**
+ * Determines the 'gebruiksnorm' (usage standard) for nitrogen for a given cultivation plan in 2026
+ * by accumulating per-teelt norms across all crops in the calendar year according to
+ * Dutch RVO's "Tabel 2 Stikstof landbouwgrond 2026".
+ *
+ * @remarks
+ * See `fdm-docs/docs/insights/fertilizer-application-norms/nl/2026/stikstofgebruiksnorm.md` for full documentation
+ * of implemented rules, footnotes (2, 6, 7a, 7b, 14, 15, 16), and out-of-scope provisions.
+ */
+export async function calculateNL2026StikstofGebruiksNorm(
+  input: NL2026NormsInput,
+): Promise<GebruiksnormResult> {
+  const has_grazing_intention = input.farm.has_grazing_intention
+  const field = input.field
+  const cultivations = input.cultivations
+
+  // Check for buffer strip
+  if (field.b_bufferstrip) {
+    return {
+      normValue: 0,
+      normSource: "Bufferstrook: geen plaatsingsruimte",
+    }
+  }
+
+  // Determine region and NV gebied
+  const is_nv_area = await isFieldInNVGebied(field.b_centroid)
+  const region = await getRegion(field.b_centroid)
+
+  // Find hoofdteelt (May 15 - July 15)
+  const hoofdteelt = findHoofdteelt(cultivations, 2026, false, true)
+
+  // Filter cultivations active in 2026
+  const yearStart = new Date(2026, 0, 1)
+  const yearEnd = new Date(2026, 11, 31, 23, 59, 59, 999)
+
+  let yearCultivations = cultivations.filter((c) => {
+    // Must overlap with the norm year
+    const start = c.b_lu_start ? new Date(c.b_lu_start) : yearStart
+    const end = c.b_lu_end ? new Date(c.b_lu_end) : yearEnd
+    if (start > yearEnd || end < yearStart) return false
+
+    // If it started before the norm year, it is only included if it is the hoofdteelt of the norm year
+    if (c.b_lu_start && new Date(c.b_lu_start).getFullYear() < 2026) {
+      return c === hoofdteelt
+    }
+    // If it started after the norm year, it is not part of this year
+    if (c.b_lu_start && new Date(c.b_lu_start).getFullYear() > 2026) {
+      return false
+    }
+
+    return true
+  })
+
+  // If no cultivations active in 2026, use fallback hoofdteelt (groene braak)
+  if (yearCultivations.length === 0) {
+    yearCultivations = [hoofdteelt as NL2026NormsInputForCultivation]
+  }
+
+  // Sort chronologically by start date
+  const sortedCultivations = [...yearCultivations].sort((a, b) => {
+    const aTime = a.b_lu_start ? new Date(a.b_lu_start).getTime() : 0
+    const bTime = b.b_lu_start ? new Date(b.b_lu_start).getTime() : 0
+    return aTime - bTime
+  })
+
+  // Determine which index in sortedCultivations is the hoofdteelt
+  const hoofdteeltIndex = sortedCultivations.findIndex(
+    (c) => c.b_lu_catalogue === hoofdteelt.b_lu_catalogue,
+  )
+
+  let totalNormValue = new Decimal(0)
+  const normBreakdownItems: Array<{
+    sourceName: string
+    subTypeText: string
+    noteText: string
+    normValue: Decimal
+  }> = []
+
+  for (let i = 0; i < sortedCultivations.length; i++) {
+    const cult = sortedCultivations[i]
+    const isHoofd = hoofdteeltIndex !== -1 ? i === hoofdteeltIndex : i === 0
+    const prevCults = sortedCultivations.slice(0, i)
+
+    const result = calculateSingleCultivationNorm(
+      cult,
+      isHoofd,
+      prevCults,
+      cultivations,
+      has_grazing_intention,
+      region,
+      is_nv_area,
+    )
+
+    totalNormValue = totalNormValue.plus(result.normValue)
+    normBreakdownItems.push(result)
+  }
 
   // Apply korting
   const { amount: kortingAmount, description: kortingDescription } = calculateKorting(
@@ -669,31 +733,35 @@ export async function calculateNL2026StikstofGebruiksNorm(
     region,
     is_nv_area,
   )
-  normValue = new Decimal(normValue).minus(kortingAmount)
+  let finalNormValue = totalNormValue.minus(kortingAmount)
 
   // If normvalue is negative, e.g. Geen plaatsingsruimte plus korting, set it to 0
-  if (normValue.isNegative()) {
-    normValue = new Decimal(0)
+  if (finalNormValue.isNegative()) {
+    finalNormValue = new Decimal(0)
   }
 
-  const subTypeText = subTypeOmschrijving ? ` (${subTypeOmschrijving})` : ""
+  let normSourceStr: string
+  if (normBreakdownItems.length === 1) {
+    const item = normBreakdownItems[0]
+    normSourceStr = `${item.sourceName}${item.subTypeText}${item.noteText}${kortingDescription}`
+  } else {
+    const breakdown = normBreakdownItems
+      .map(
+        (item) =>
+          `${item.sourceName}${item.subTypeText}${item.noteText} (${item.normValue.toNumber()} kg N/ha)`,
+      )
+      .join(" + ")
+    normSourceStr = `${breakdown}${kortingDescription}`
+  }
+
   return {
-    normValue: normValue.toNumber(),
-    normSource: `${selectedStandard.cultivation_rvo_table2}${subTypeText}${kortingDescription}`,
+    normValue: finalNormValue.toNumber(),
+    normSource: normSourceStr,
   }
 }
 
 /**
  * Memoized version of {@link calculateNL2026StikstofGebruiksNorm}.
- *
- * This function is wrapped with `withCalculationCache` to optimize performance by caching
- * results based on the input and the current calculator version.
- *
- * @param {NL2026NormsInput} input - An object of type `NL2026NormsInput` containing all necessary data.
- * @returns {Promise<GebruiksnormResult>} A promise that resolves to an object of type `GebruiksnormResult` containing:
- *   - `normValue`: The determined nitrogen usage standard in kilograms per hectare (kg/ha).
- *   - `normSource`: The descriptive name from RVO Table 2 used for the calculation.
- *   - `kortingDescription`: A description of any korting (reduction) applied to the norm.
  */
 export const getNL2026StikstofGebruiksNorm = withCalculationCache(
   calculateNL2026StikstofGebruiksNorm,

--- a/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.ts
+++ b/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.ts
@@ -27,7 +27,25 @@ import {
 import { nitrogenStandardsData } from "./stikstofgebruiksnorm-data"
 
 /**
- * Determines the specific sub-type 'omschrijving' for a cultivation that is part of a larger group.
+ * Determines the specific sub-type 'omschrijving' for a cultivation in 2026.
+ *
+ * Sub-types in RVO Tabel 2 differentiate nitrogen norms based on crop management, cultivation history,
+ * or botanical characteristics:
+ * - **Grasland**: Differentiates between grazing (`beweiden`) and pure mowing (`volledig maaien`).
+ * - **Aardappel**: Matches specific potato varieties to standard groupings (e.g. early, late, seed, starch).
+ * - **Mais**: No subtype applies in 2026 (derogation expired at the end of 2025).
+ * - **Luzerne**: Differentiates first-year (`eerste jaar`) from subsequent years (`volgende jaren`) based on prior-year presence.
+ * - **Koolzaad**: Differentiates winter (`winter`, `nl_1922`) from summer (`zomer`, `nl_1923`) varieties.
+ * - **Gras voor industriële verwerking / Graszaad / Roodzwenkgras**: Differentiates establishment / 1st year from multi-year / overjarig stands.
+ * - **Zaaiui / Winterui**: Differentiates 1st year (`nl_1932`) from 2nd year (`nl_1933`).
+ * - **Bladgewassen (Spinazie, Slasoorten, Andijvie)**: Differentiates 1st cultivation (`1e teelt`) for the main crop from subsequent cultivation (`volgteelt`).
+ *
+ * @param cultivation - The cultivation object being evaluated.
+ * @param standard - The matching `NitrogenStandard` definition from Tabel 2 (2026).
+ * @param cultivations - All cultivations on the field (used to inspect cultivation history across years).
+ * @param has_grazing_intention - Grazing intention for grassland parcels.
+ * @param isHoofdteelt - Whether this cultivation is the designated main crop (`hoofdteelt`) of the year.
+ * @returns The matching sub-type description key, or `undefined` if no specific sub-type applies.
  */
 function determineSubTypeOmschrijving(
   cultivation: NL2026NormsInputForCultivation,
@@ -140,8 +158,27 @@ function determineSubTypeOmschrijving(
 }
 
 /**
- * Calculates the "korting" (reduction) on the nitrogen usage norm based on the presence
- * of winter crops or catch crops in the previous year.
+ * Calculates statutory reductions ("kortingen") on the annual nitrogen usage norm for 2026.
+ *
+ * Implements three statutory reduction mechanisms:
+ * 1. **Grassland renewal (Graslandvernieuwing, Footnote 14)**:
+ *    - Applies a **50 kg N/ha** reduction when grassland is renewed (gras-na-gras transition) between 1 June and 31 August.
+ *    - In 2026: Applies on all soil types (sand, loess, clay, peat) for all farms (as derogation no longer exists in 2026).
+ * 2. **Grassland destruction (Graslandvernietiging / Scheuren)**:
+ *    - Applies a **65 kg N/ha** reduction when grassland is converted to arable land (gras-naar-bouwland transition)
+ *      for maize or eligible potato cultivations (excluding seed potatoes and early harvest varieties).
+ *    - Allowed destruction windows:
+ *      - Sand & Loess: 1 February – 10 May.
+ *      - Clay & Peat (NV-gebied): 1 February – 15 March.
+ *      - Clay & Peat (Non-NV): 1 February – 31 May.
+ *    - Catch crops (vanggewas) sown in autumn of the previous year are excluded from triggering grassland destruction korting.
+ * 3. **Article 28d Meststoffenwet (Catch crops and winter crops after sand/loess main crops)**:
+ *    - Evaluated by `calculateVanggewasWinterteeltKorting` anchored to the main crop of year N-1.
+ *
+ * @param cultivations - Array of cultivations across current and preceding years.
+ * @param region - Soil region (`zand_nwc`, `zand_zuid`, `loess`, `klei`, `veen`).
+ * @param is_nv_area - Flag indicating if the parcel is located in a nutrient-polluted zone (NV-gebied).
+ * @returns An object containing the total reduction amount (Decimal) and formatted descriptive text.
  */
 function calculateKorting(
   cultivations: NL2026NormsInputForCultivation[],
@@ -278,7 +315,38 @@ function calculateKorting(
 }
 
 /**
- * Calculates the nitrogen norm for a single cultivation in 2026.
+ * Calculates the nitrogen usage standard for an individual cultivation in 2026 according to RVO Tabel 2.
+ *
+ * This function performs multi-step agronomic compliance checks:
+ * 1. **Standard & Subtype Resolution**: Matches `b_lu_catalogue` to Tabel 2 (2026) records. For non-main crops (`!isHoofdteelt`),
+ *    it prioritizes explicit `volgteelt` entries where available.
+ * 2. **Regional & NV-area Norm Selection**: Fetches the applicable base norm in kg N/ha for the field's soil region
+ *    and NV-gebied designation.
+ * 3. **Footnote 2 & 6 Compliance (Maïs follow-up suppression)**:
+ *    - Suppresses norms (sets 0 kg N/ha) for green manures (`Groenbemesters`), catch crops (`is_vanggewas`),
+ *      and temporary grassland (`tijdelijkGraslandCodes`) following maize on the same field in the calendar year.
+ * 4. **Footnote 7a Compliance (Green manure conditions)**:
+ *    - Green manure norms (`Groenbemesters, niet-vlinderbloemige`) are conditional upon:
+ *      - Having an immediate preceding crop in the same calendar year.
+ *      - Preceding crop being a cereal (`graanCodes`), grass seed (`graszaadCodes`), or rapeseed (`koolzaadCodes`) for a full 100% norm.
+ *      - On sand/loess following temporary grassland (`tijdelijkGraslandCodes`), granting a 50% norm.
+ *      - Sowing date strictly before 1 September.
+ *      - Standing until at least 1 February of the following year.
+ *    - If conditions are unmet, grants 0 kg N/ha with an explanatory status note.
+ * 5. **Footnote 7b Compliance (Graszaadstoppel)**:
+ *    - Requires cultivation start on or before 16 September; otherwise grants 0 kg N/ha.
+ * 6. **Grassland Renewal Sod Continuation**:
+ *    - Resown grassland (`isGrass && hasGrassBeforeInYear`) shares the single annual grassland allowance (0 kg N/ha for 2nd sod).
+ *
+ * @param cultivation - The cultivation being calculated.
+ * @param isHoofdteelt - True if this cultivation is the designated main crop of the year.
+ * @param prevCultivationsInYear - Prior cultivations in the same calendar year on this parcel.
+ * @param cultivations - Complete array of cultivations on the field.
+ * @param has_grazing_intention - Grazing intention for grassland parcels.
+ * @param region - Soil region classification.
+ * @param is_nv_area - Nutrient-polluted area (NV-gebied) indicator.
+ * @returns Object containing the calculated norm value, standard name, subtype text, and explanatory footnote note.
+ * @throws {NormNotApplicableError} If no matching crop standard exists in Tabel 2.
  */
 function calculateSingleCultivationNorm(
   cultivation: NL2026NormsInputForCultivation,
@@ -487,13 +555,28 @@ function calculateSingleCultivationNorm(
 }
 
 /**
- * Determines the 'gebruiksnorm' (usage standard) for nitrogen for a given cultivation plan in 2026
- * by accumulating per-teelt norms across all crops in the calendar year according to
- * Dutch RVO's "Tabel 2 Stikstof landbouwgrond 2026".
+ * Determines the 'gebruiksnorm' (nitrogen application standard) for a given field and cultivation plan in 2026
+ * by accumulating per-teelt norms across all active crops in the calendar year according to
+ * Dutch RVO "Tabel 2 Stikstof landbouwgrond 2026".
  *
- * @remarks
- * See `fdm-docs/docs/insights/fertilizer-application-norms/nl/2026/stikstofgebruiksnorm.md` for full documentation
- * of implemented rules, footnotes (2, 6, 7a, 7b, 14, 15, 16), and out-of-scope provisions.
+ * ### Agronomic & Legal Workflow:
+ * 1. **Buffer Strip Check**: Parcels marked with `b_bufferstrip` receive 0 kg N/ha.
+ * 2. **Geographical Resolution**: Determines soil type (`getRegion`) and NV-gebied status (`isFieldInNVGebied`).
+ * 3. **Main Crop Identification**: Identifies the statutory `hoofdteelt` (present between 15 May and 15 July).
+ * 4. **Multi-Teelt Accumulation**:
+ *    - Iterates over all active cultivations in the calendar year (including overwintering main crops).
+ *    - The main crop receives its 1st cultivation standard (`1e teelt`).
+ *    - Successive crops receive volgteelt / subtype standards with applicable footnote checks (footnotes 2, 6, 7a, 7b).
+ * 5. **Statutory Reductions ("Kortingen")**:
+ *    - Grassland renewal reduction (50 kg N/ha on all soils, footnote 14).
+ *    - Grassland destruction reduction (65 kg N/ha).
+ *    - Article 28d catch-crop / winter-crop shortfall reductions.
+ * 6. **Floor & Formatting**: Enforces non-negative norm floor (min 0) and generates a detailed audit breakdown string.
+ *
+ * @param input - Input data containing farm settings, field centroid/bufferstrip, and cultivation schedule.
+ * @returns An object containing the aggregated `normValue` (in kg N/ha) and the descriptive `normSource`.
+ *
+ * @see `fdm-docs/docs/insights/fertilizer-application-norms/nl/2026/stikstofgebruiksnorm.md`
  */
 export async function calculateNL2026StikstofGebruiksNorm(
   input: NL2026NormsInput,

--- a/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.ts
+++ b/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.ts
@@ -539,21 +539,9 @@ function calculateSingleCultivationNorm(
 
   if (hasMaizeBefore && isGroenbemesterOrCatchOrTempGrass) {
     normValue = new Decimal(0)
-    noteText = " (geen norm na maïs, voetnoot 2/6)"
+    noteText = " (geen extra ruimte na maïs, voetnoot 2/6)"
   } else if (selectedStandard.cultivation_rvo_table2 === "Groenbemesters, niet-vlinderbloemige") {
     // Footnote 7a: Groenbemester conditions
-    const isSownBeforeSept1 =
-      cultivation.b_lu_start &&
-      (cultivation.b_lu_start.getFullYear() < 2026 ||
-        (cultivation.b_lu_start.getFullYear() === 2026 &&
-          (cultivation.b_lu_start.getMonth() < 8 ||
-            (cultivation.b_lu_start.getMonth() === 8 &&
-              cultivation.b_lu_start.getDate() === 1 &&
-              cultivation.b_lu_start.getHours() === 0))))
-
-    const isNotDestroyedBeforeFeb1 =
-      !cultivation.b_lu_end || cultivation.b_lu_end >= new Date(2027, 1, 1)
-
     const immediatePrecedingCrop =
       prevCultivationsInYear.length > 0
         ? prevCultivationsInYear[prevCultivationsInYear.length - 1]
@@ -571,25 +559,40 @@ function calculateSingleCultivationNorm(
 
     const isSandyOrLoess = ["zand_nwc", "zand_zuid", "loess"].includes(region)
 
-    if (!isSownBeforeSept1) {
+    const isSownBeforeSept1 =
+      cultivation.b_lu_start &&
+      (cultivation.b_lu_start.getFullYear() < 2026 ||
+        (cultivation.b_lu_start.getFullYear() === 2026 &&
+          (cultivation.b_lu_start.getMonth() < 8 ||
+            (cultivation.b_lu_start.getMonth() === 8 &&
+              cultivation.b_lu_start.getDate() === 1 &&
+              cultivation.b_lu_start.getHours() === 0))))
+
+    const isNotDestroyedBeforeFeb1 =
+      !cultivation.b_lu_end || cultivation.b_lu_end >= new Date(2027, 1, 1)
+
+    if (!immediatePrecedingCrop) {
       normValue = new Decimal(0)
-      noteText = " (geen norm: gezaaid op of na 1 september, voetnoot 7a)"
+      noteText = " (geen extra ruimte: geen voorafgaande teelt, voetnoot 7a)"
+    } else if (
+      !isPrecedingCerealOrRapeseedOrGrassSeed &&
+      !(isSandyOrLoess && isPrecedingGrasOpBouwland)
+    ) {
+      normValue = new Decimal(0)
+      noteText = " (geen extra ruimte: niet geteeld na granen, graszaad of koolzaad, voetnoot 7a)"
+    } else if (!isSownBeforeSept1) {
+      normValue = new Decimal(0)
+      noteText = " (geen extra ruimte: gezaaid op of na 1 september, voetnoot 7a)"
     } else if (!isNotDestroyedBeforeFeb1) {
       normValue = new Decimal(0)
-      noteText = " (geen norm: vernietigd vóór 1 februari, voetnoot 7a)"
-    } else if (!immediatePrecedingCrop) {
-      normValue = new Decimal(0)
-      noteText = " (geen norm: geen voorafgaande teelt, voetnoot 7a)"
+      noteText = " (geen extra ruimte: vernietigd vóór 1 februari, voetnoot 7a)"
     } else if (isPrecedingCerealOrRapeseedOrGrassSeed) {
       // 100% of norm
       noteText = " (volgteelt na granen, graszaad of koolzaad, voetnoot 7a)"
     } else if (isSandyOrLoess && isPrecedingGrasOpBouwland) {
       // 50% of norm on sand or loess after grass on arable land
       normValue = normValue.dividedBy(2)
-      noteText = " (50% norm na gras op bouwland, voetnoot 7a)"
-    } else {
-      normValue = new Decimal(0)
-      noteText = " (geen norm: niet geteeld na granen, graszaad of koolzaad, voetnoot 7a)"
+      noteText = " (extra ruimte (50%) na gras op bouwland, voetnoot 7a)"
     }
   }
 
@@ -607,7 +610,7 @@ function calculateSingleCultivationNorm(
       noteText = " (graszaadstoppel, voetnoot 7b)"
     } else {
       normValue = new Decimal(0)
-      noteText = " (geen norm: niet voldaan aan voorwaarden graszaadstoppel, voetnoot 7b)"
+      noteText = " (geen extra ruimte: niet voldaan aan voorwaarden graszaadstoppel, voetnoot 7b)"
     }
   }
 

--- a/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.ts
+++ b/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.ts
@@ -441,15 +441,20 @@ function calculateSingleCultivationNorm(
   let noteText = ""
 
   // Footnote 2 & 6: Suppression of groenbemester, tijdelijk grasland and vanggewas norms after maize
+  const immediatePrecedingCrop =
+    prevCultivationsInYear.length > 0
+      ? prevCultivationsInYear[prevCultivationsInYear.length - 1]
+      : undefined
+
   const hasMaizeBefore =
     !isHoofdteelt &&
-    prevCultivationsInYear.some(
-      (c) =>
-        maisCodes.includes(c.b_lu_catalogue) ||
+    Boolean(
+      immediatePrecedingCrop &&
+      (maisCodes.includes(immediatePrecedingCrop.b_lu_catalogue) ||
         nitrogenStandardsData
-          .find((ns) => ns.b_lu_catalogue_match.includes(c.b_lu_catalogue))
+          .find((ns) => ns.b_lu_catalogue_match.includes(immediatePrecedingCrop.b_lu_catalogue))
           ?.cultivation_rvo_table2.toLowerCase()
-          .includes("mais"),
+          .includes("mais")),
     )
 
   const isGroenbemesterOrCatchOrTempGrass =
@@ -463,11 +468,6 @@ function calculateSingleCultivationNorm(
     noteText = " (geen extra ruimte na maïs, voetnoot 2/6)"
   } else if (selectedStandard.cultivation_rvo_table2 === "Groenbemesters, niet-vlinderbloemige") {
     // Footnote 7a: Groenbemester conditions
-    const immediatePrecedingCrop =
-      prevCultivationsInYear.length > 0
-        ? prevCultivationsInYear[prevCultivationsInYear.length - 1]
-        : undefined
-
     const isPrecedingCerealOrRapeseedOrGrassSeed =
       immediatePrecedingCrop &&
       (graanCodes.includes(immediatePrecedingCrop.b_lu_catalogue) ||
@@ -483,11 +483,7 @@ function calculateSingleCultivationNorm(
     const isSownBeforeSept1 =
       cultivation.b_lu_start &&
       (cultivation.b_lu_start.getFullYear() < 2026 ||
-        (cultivation.b_lu_start.getFullYear() === 2026 &&
-          (cultivation.b_lu_start.getMonth() < 8 ||
-            (cultivation.b_lu_start.getMonth() === 8 &&
-              cultivation.b_lu_start.getDate() === 1 &&
-              cultivation.b_lu_start.getHours() === 0))))
+        (cultivation.b_lu_start.getFullYear() === 2026 && cultivation.b_lu_start.getMonth() < 8))
 
     const isNotDestroyedBeforeFeb1 =
       !cultivation.b_lu_end || cultivation.b_lu_end >= new Date(2027, 1, 1)
@@ -525,7 +521,7 @@ function calculateSingleCultivationNorm(
     const isBeforeSept16 =
       !cultivation.b_lu_start ||
       cultivation.b_lu_start.getMonth() < 8 ||
-      (cultivation.b_lu_start.getMonth() === 8 && cultivation.b_lu_start.getDate() <= 16)
+      (cultivation.b_lu_start.getMonth() === 8 && cultivation.b_lu_start.getDate() < 16)
 
     if (isBeforeSept16) {
       noteText = " (graszaadstoppel, voetnoot 7b)"
@@ -540,7 +536,7 @@ function calculateSingleCultivationNorm(
   const hasGrassBeforeInYear = prevCultivationsInYear.some((c) =>
     nonBouwlandCodes.includes(c.b_lu_catalogue),
   )
-  if (!isHoofdteelt && isGrass && hasGrassBeforeInYear) {
+  if (isGrass && hasGrassBeforeInYear) {
     normValue = new Decimal(0)
     noteText = " (heringezaaid)"
   }
@@ -636,7 +632,7 @@ export async function calculateNL2026StikstofGebruiksNorm(
 
   // Determine which index in sortedCultivations is the hoofdteelt
   const hoofdteeltIndex = sortedCultivations.findIndex(
-    (c) => c.b_lu_catalogue === hoofdteelt.b_lu_catalogue,
+    (c) => (c.b_lu && hoofdteelt.b_lu ? c.b_lu === hoofdteelt.b_lu : c === hoofdteelt),
   )
 
   let totalNormValue = new Decimal(0)

--- a/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.ts
+++ b/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.ts
@@ -5,13 +5,16 @@ import type {
   NitrogenStandard,
   NL2026NormsInput,
   NL2026NormsInputForCultivation,
-  NormsByRegion,
   RegionKey,
 } from "./types"
 import { NormNotApplicableError } from "../../../../error"
 import pkg from "../../../../package"
 import { findHoofdteelt } from "../../../../shared/hoofdteelt"
-import { getRegion, isFieldInNVGebied } from "../../2025/value/stikstofgebruiksnorm"
+import {
+  getNormsForCultivation,
+  getRegion,
+  isFieldInNVGebied,
+} from "../../2025/value/stikstofgebruiksnorm"
 import { calculateVanggewasWinterteeltKorting } from "../../2025/value/vanggewas-winterteelt"
 import {
   graanCodes,
@@ -22,156 +25,6 @@ import {
   tijdelijkGraslandCodes,
 } from "../../constant"
 import { nitrogenStandardsData } from "./stikstofgebruiksnorm-data"
-
-/**
- * Retrieves the appropriate set of nitrogen norms (`NormsByRegion`) for a given cultivation.
- */
-function getNormsForCultivation(
-  selectedStandard: NitrogenStandard,
-  b_lu_end: Date,
-  b_lu_start: Date | null | undefined,
-  subTypeOmschrijving?: string,
-): NormsByRegion | undefined {
-  if (selectedStandard.sub_types) {
-    type SubType = NonNullable<NitrogenStandard["sub_types"]>[number]
-    let matchingSubType: SubType | undefined
-
-    // 1. Check for a direct match on omschrijving
-    if (subTypeOmschrijving) {
-      matchingSubType = selectedStandard.sub_types.find(
-        (sub) => sub.omschrijving === subTypeOmschrijving,
-      )
-      if (matchingSubType) {
-        return matchingSubType.norms
-      }
-    }
-
-    // 2. Fallback to time-based logic for temporary grasslands if no omschrijving match
-    const endDate = new Date(b_lu_end)
-    endDate.setHours(12, 0, 0, 0) // Avoid timezone issues at midnight
-    const startDate = b_lu_start ? new Date(b_lu_start) : new Date(endDate.getFullYear(), 0, 1)
-    startDate.setHours(12, 0, 0, 0)
-
-    // Find all matching sub-types
-    const potentialMatches = selectedStandard.sub_types.filter((sub) => {
-      if (
-        sub.period_start_month !== null &&
-        sub.period_start_month !== undefined &&
-        sub.period_end_month !== null &&
-        sub.period_end_month !== undefined
-      ) {
-        const startPeriod = new Date(
-          endDate.getFullYear(),
-          sub.period_start_month - 1,
-          sub.period_start_day ?? 1,
-          12,
-          0,
-          0,
-          0,
-        )
-        const endPeriod = new Date(
-          endDate.getFullYear(),
-          sub.period_end_month - 1,
-          sub.period_end_day ?? 1,
-          12,
-          0,
-          0,
-          0,
-        )
-
-        // Handle periods that might wrap (though none currently do in the data)
-        if (sub.period_start_month > sub.period_end_month) {
-          endPeriod.setFullYear(endDate.getFullYear() + 1)
-        }
-
-        // Special handling for "vanaf" (Late sowing or summer/autumn teelten)
-        // For "vanaf" periods, the crop must start on or after the startPeriod.
-        const isVanaf =
-          sub.period_start_month !== null &&
-          sub.period_start_month !== undefined &&
-          sub.period_start_month > 1
-
-        if (isVanaf) {
-          // If it's a "tot minstens" period (implied by end month < 12), it must also last until endPeriod,
-          // and the crop must have been sown on or before endPeriod (cannot start after the period has ended).
-          if (
-            sub.period_end_month !== null &&
-            sub.period_end_month !== undefined &&
-            sub.period_end_month < 12
-          ) {
-            return startDate >= startPeriod && startDate <= endPeriod && endDate >= endPeriod
-          }
-          // For "vanaf X" (without "tot minstens", e.g. "vanaf 15 oktober"), we only check if it starts on or after X.
-          return startDate >= startPeriod
-        }
-
-        // Standard "van 1 januari tot minstens X" logic:
-        // Crop must be present from startPeriod (or earlier) to at least endPeriod.
-        return startDate <= startPeriod && endDate >= endPeriod
-      }
-      return false
-    })
-
-    // Select the best match
-    // Prefer the one with the *earliest* period_start (most specific start requirement)
-    // If tied, prefer the one with the *latest* period_end (longest mandated duration = typically higher norm)
-    if (potentialMatches.length > 0) {
-      potentialMatches.sort((a, b) => {
-        const aStart = (a.period_start_month ?? -1) * 100 + (a.period_start_day ?? -1)
-        const bStart = (b.period_start_month ?? -1) * 100 + (b.period_start_day ?? -1)
-        if (aStart !== bStart) {
-          return aStart - bStart
-        }
-        const aEnd = (a.period_end_month ?? -1) * 100 + (a.period_end_day ?? -1)
-        const bEnd = (b.period_end_month ?? -1) * 100 + (b.period_end_day ?? -1)
-        return bEnd - aEnd
-      })
-      matchingSubType = potentialMatches[0]
-    }
-
-    // If no match found using the stricter "minstens" logic, fallback to the original bucket logic
-    // to prevent "undefined" regressions for edge cases, but with timezone fix.
-    if (!matchingSubType) {
-      matchingSubType = selectedStandard.sub_types.find((sub) => {
-        if (
-          sub.period_start_month !== null &&
-          sub.period_start_month !== undefined &&
-          sub.period_end_month !== null &&
-          sub.period_end_month !== undefined
-        ) {
-          const startPeriod = new Date(
-            endDate.getFullYear(),
-            sub.period_start_month - 1,
-            sub.period_start_day ?? 1,
-            12,
-            0,
-            0,
-            0,
-          )
-          const endPeriod = new Date(
-            endDate.getFullYear(),
-            sub.period_end_month - 1,
-            sub.period_end_day ?? 1,
-            12,
-            0,
-            0,
-            0,
-          )
-          if (sub.period_start_month > sub.period_end_month) {
-            endPeriod.setFullYear(endDate.getFullYear() + 1)
-          }
-          return endDate >= startPeriod && endDate <= endPeriod
-        }
-        return false
-      })
-    }
-
-    return matchingSubType?.norms
-  }
-
-  // Default case if no sub_types are defined
-  return selectedStandard.norms
-}
 
 /**
  * Determines the specific sub-type 'omschrijving' for a cultivation that is part of a larger group.

--- a/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.ts
+++ b/fdm-calculator/src/norms/nl/2026/value/stikstofgebruiksnorm.ts
@@ -631,8 +631,8 @@ export async function calculateNL2026StikstofGebruiksNorm(
   })
 
   // Determine which index in sortedCultivations is the hoofdteelt
-  const hoofdteeltIndex = sortedCultivations.findIndex(
-    (c) => (c.b_lu && hoofdteelt.b_lu ? c.b_lu === hoofdteelt.b_lu : c === hoofdteelt),
+  const hoofdteeltIndex = sortedCultivations.findIndex((c) =>
+    c.b_lu && hoofdteelt.b_lu ? c.b_lu === hoofdteelt.b_lu : c === hoofdteelt,
   )
 
   let totalNormValue = new Decimal(0)

--- a/fdm-calculator/src/norms/nl/constant.ts
+++ b/fdm-calculator/src/norms/nl/constant.ts
@@ -1,1 +1,60 @@
 export const nonBouwlandCodes = ["nl_265", "nl_266", "nl_331", "nl_332", "nl_335"]
+
+export const graanCodes = [
+  "nl_233",
+  "nl_382",
+  "nl_234",
+  "nl_235",
+  "nl_236",
+  "nl_381",
+  "nl_314",
+  "nl_237",
+  "nl_6806",
+  "nl_238",
+  "nl_670",
+  "nl_6636",
+]
+
+export const koolzaadCodes = ["nl_1922", "nl_1923"]
+
+export const graszaadCodes = [
+  "nl_1915",
+  "nl_1916",
+  "nl_1917",
+  "nl_1918",
+  "nl_1919",
+  "nl_1920",
+  "nl_383",
+  "nl_1914",
+  "nl_6768",
+  "nl_1034",
+  "nl_1035",
+  "nl_6752",
+  "nl_6753",
+  "nl_2030",
+  "nl_2031",
+  "nl_3506",
+  "nl_3512",
+  "nl_3513",
+  "nl_3516",
+  "nl_3523",
+  "nl_3807",
+  "nl_3808",
+  "nl_6746",
+  "nl_6750",
+  "nl_6751",
+  "nl_6754",
+  "nl_6755",
+  "nl_6782",
+  "nl_6783",
+  "nl_6784",
+  "nl_6785",
+  "nl_6788",
+  "nl_6789",
+  "nl_6790",
+  "nl_6791",
+]
+
+export const maisCodes = ["nl_259", "nl_316", "nl_317", "nl_1935", "nl_2032"]
+
+export const tijdelijkGraslandCodes = ["nl_266"]

--- a/fdm-docs/docs/insights/fertilizer-application-norms/nl/2025/stikstofgebruiksnorm.md
+++ b/fdm-docs/docs/insights/fertilizer-application-norms/nl/2025/stikstofgebruiksnorm.md
@@ -11,30 +11,52 @@ This document provides a detailed explanation of the Dutch legal usage norm (`ge
 
 ### How the Norm Works
 
-The nitrogen usage norm sets the maximum total effective nitrogen (in kg N/ha) that can be applied to a field. The calculation follows a step-by-step process to find the most precise norm based on various factors.
+The nitrogen usage norm sets the maximum total effective nitrogen (in kg N/ha) that can be applied to a field in a calendar year. Per RVO Tabel 2, norms are determined **per hectare per teelt** and summed across all crops grown on a field in the calendar year.
 
 #### Calculation Steps
 
-1. **Identify Main Crop**: The main crop for 2025 is determined from your cultivation plan.
+1. **Identify Main Crop (`hoofdteelt`)**: The main crop for 2025 is determined using the Dutch regulatory reference window: the crop present for the longest duration between **15 May and 15 July**. If no crop covers that window, the field falls back to green fallow (`Groene braak, spontane opkomst`).
 2. **Determine Geographical Context**: The field's location is used to check:
-   - If it is in a **Nutrient-Polluted Area (`NV-gebied`)**, which results in a stricter (lower) norm.
+   - If it is in a **Nutrient-Polluted Area (`NV-gebied`)**, which results in a stricter (20% lower) norm.
    - The dominant **soil region** (`zand_nwc`, `zand_zuid`, `klei`, `veen`, or `loess`).
-3. **Find the Standard Norm**: The main crop is looked up in the official RVO Table 2 (or Tabel 2g for NV-gebieden).
+3. **Calculate Per-Crop Norms**: For each crop grown in the norm year:
+   - **First Crop (`1e teelt`)**: The hoofdteelt receives the primary standard norm from RVO Tabel 2.
+   - **Successive Crops (`Volgteelt`)**: Any crop following the main crop receives its volgteelt norm where defined in Tabel 2 (e.g. spinach, lettuce varieties, endive, meadow grass, red fescue, tall fescue).
+   - **Green Manures (`Groenbemesters`)**: Non-leguminous catch crops receive the groenbemester norm (60/50/50/50/60 kg N/ha) if statutory conditions of footnote 7a are met (sown before 1 September following cereals, rapeseed, or grass seed; not destroyed before 1 February of the next year; or 50% on sand/loess after temporary grassland).
+   - **Exclusion after Maize**: Per footnotes 2 and 6, no additional norm is granted for green manures, catch crops, or temporary grassland following maize.
 4. **Apply Specific Rules**: The standard norm is refined with additional rules for certain crops:
-   - **Temporary Grassland (`Tijdelijk grasland`)**: The norm is adjusted based on the cultivation end date.
+   - **Grassland (`Grasland`)**: The norm depends on whether the grassland is grazed (`beweiden`) or fully mown (`volledig maaien`).
+   - **Temporary Grassland (`Tijdelijk grasland`)**: The norm is adjusted based on the cultivation period.
    - **Potatoes (`Aardappelen`)**: The norm is adjusted based on the potato variety. See [RVO Tabel 2c](https://www.rvo.nl/sites/default/files/2024-12/Tabel-2c-Consumptieaardappelen%20hoge%20of%20lage%20norm-2025.pdf).
-   - **Maize (`Maïs`)**: The norm depends on the farm's derogation status.
+   - **Maize (`Maïs`)**: The norm depends on the farm's derogation status (160 kg N/ha derogation vs 185 kg N/ha no derogation on clay).
    - **Outdoor Flowers (`Buitenbloemen`)**: A higher norm is applied for specific varieties.
-5. **Select the Final Norm**: The final value is selected based on the field's soil region and `NV-gebied` status.
-6. **Apply Nitrogen Usage Norm Reductions (`Kortingen`)**: The norm is reduced if catch crop (`vanggewas`) or winter crop (`winterteelt`) requirements were not met in the **previous** year on sand and loess soils, and/or if grassland was renewed or destroyed. Reductions are **cumulative**: they are added together rather than applied as alternatives. If the result would be negative, it is set to 0.
+5. **Sum Cultivation Norms**: The total field nitrogen allowance is the sum of norms across all cultivations in the year.
+6. **Apply Nitrogen Usage Norm Reductions (`Kortingen`)**: Reductions are subtracted from the total:
+   - **Catch crop reduction (art. 28d Urm)**: Assessed on the previous calendar year (2024) on sand and loess.
+   - **Grassland renewal (gras-na-gras, footnote 14)**: 50 kg N/ha reduction when grassland is renewed between **1 June and 31 August** (on sand/loess for all farms; on clay/peat only for derogation farms).
+   - **Grassland destruction (gras-naar-bouwland, footnotes 15/16)**: 65 kg N/ha reduction when destroyed for maize or eligible consumption/factory potatoes within allowed spring windows (excluding previous catch-crop grass).
+   - Reductions are **cumulative**. If the total norm would become negative, it is floored at 0.
 
-### How the FDM Calculator Determines the Norm
+A field marked as a buffer strip (`b_bufferstrip`) receives a norm of 0.
 
-The `fdm-calculator` uses the `calculateNitrogenUsageNorm` function in `fdm-calculator/src/norms/nl/2025/value/stikstofgebruiksnorm.ts`, which relies on:
+### Intentional Crop Code Mappings
 
-- **`stikstofgebruiksnorm-data.ts`**: Contains the data from RVO Tabel 2 and Tabel 2g.
-- **`input.ts`**: Defines the required inputs, such as derogation status, location, and crop data. Note that cultivations are collected from **1 January of the previous year**, because the catch crop rules depend on what was grown then.
-- **`../../vanggewas-winterteelt.ts`**: Determines whether a crop is a catch crop and/or a winter crop, and evaluates the statutory conditions attached to specific crops.
+- **Quinoa (`nl_1022`)**: Mapped to `Bladgewassen, Spinazie volgteelt` per official RVO gewascodes guidelines.
+- **Grass-like Catch Crops (`nl_6751`, `nl_6789`, `nl_6753`)**: Mapped to their respective grass-seed norm rows (`Akkerbouwgewassen, Graszaad, ...`) per RVO classification.
+- **Nature, green fallow and non-agricultural areas (`nl_332`, `nl_335`, `nl_6794`)**: Mapped to `Geen plaatsingsruimte` (0 kg N/ha).
+
+---
+
+## Provisions Not (Yet) Implemented
+
+The following statutory options and specialized exceptions from the _Uitvoeringsregeling Meststoffenwet_ are currently out of scope:
+
+1. **Yield-based norm increases (`Opbrengstafhankelijke verhoging` / `Stikstofdifferentiatie`, art. 28c Urm / Bijlage A Tabel 1a)**: Higher norms for sugar beets, potatoes, cereals, and vegetables based on 3-year verified historical yield records.
+2. **French-fry potatoes on clay (`Fritesaardappelen op klei`, Tabel 2a)**: Differentiated nitrogen norms requiring specific registration.
+3. **Grass seed with fodder cut (`Graszaad met voedersnede`)**: Combining grass seed norm with temporary grassland norm when a fodder cut is taken in spring/autumn.
+4. **Mixed crops / Undersowing (`Mengteelt / Onderzaai`)**: Differentiated calculation for intercropped arable plants.
+5. **Fixed farm-level nitrogen norm (`Vaste norm op bedrijfsniveau`, footnote 9)**: The 110 kg N/ha fixed allowance when the farm's weighted average is between 100 and 110 kg N/ha.
+6. **Two-year winter crop budget split (`Winterteelt "waarvan ten hoogste na 31/12"`, footnote 5/18)**: Multi-year budget cap attribution between sowing year and harvest year.
 
 ---
 
@@ -54,11 +76,11 @@ The reduction applied to the 2025 norm is caused by what happened in autumn 2024
 
 No reduction applies if a designated **winter crop (`winterteelt`)** covered the ground instead of a catch crop. Winter crops fall into three groups, and the group determines which crop the calculator examines:
 
-| Group | Examples | Which crop is checked |
-| :---- | :------- | :-------------------- |
-| Listed as **both** a catch crop and a winter crop | winter wheat, winter barley, rye, grasses and grass-seed crops | The **main crop of the norm year** (sown in autumn of the previous year, harvested in the norm year) |
-| Winter crop only, late-harvested or perennial | sugar and fodder beet lifted on or after 1 November, Brussels sprouts, chicory, asparagus, top fruit, grassland | The **main crop of the previous year** |
-| Winter crop only, autumn-sown | spinach sown after 1 August, kohlrabi and pak choi planted after 1 August | The crop grown **after** the previous year's main crop |
+| Group                                             | Examples                                                                                                        | Which crop is checked                                                                                |
+| :------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
+| Listed as **both** a catch crop and a winter crop | winter wheat, winter barley, rye, grasses and grass-seed crops                                                  | The **main crop of the norm year** (sown in autumn of the previous year, harvested in the norm year) |
+| Winter crop only, late-harvested or perennial     | sugar and fodder beet lifted on or after 1 November, Brussels sprouts, chicory, asparagus, top fruit, grassland | The **main crop of the previous year**                                                               |
+| Winter crop only, autumn-sown                     | spinach sown after 1 August, kohlrabi and pak choi planted after 1 August                                       | The crop grown **after** the previous year's main crop                                               |
 
 For crops in the first group, the exception only applies if the crop is **not destroyed before 16 May** of the norm year — which is what makes it the main crop of that year rather than a catch crop.
 

--- a/fdm-docs/docs/insights/fertilizer-application-norms/nl/2025/stikstofgebruiksnorm.md
+++ b/fdm-docs/docs/insights/fertilizer-application-norms/nl/2025/stikstofgebruiksnorm.md
@@ -128,13 +128,10 @@ In 2025, specific nitrogen usage norm reductions (`kortingen`) apply when grassl
 
 ### 1. Grassland Renewal (Gras-na-Gras)
 
-When grassland is directly followed by new grassland, a reduction of **50 kg N/ha** applies. This is only allowed within specific periods:
+When grassland is directly followed by new grassland, a reduction of **50 kg N/ha** applies. Per footnote 14, this applies within the following conditions:
 
-- **Sand and Loess Soils**: June 1st – August 31st.
-- **Clay and Peat Soils**:
-  - **Derogation Farm + NV-Area**: June 1st – August 31st.
-  - **Derogation Farm + Non-NV-Area**: June 1st – September 15th.
-  - **Non-Derogation Farm**: February 1st – September 15th.
+- **Sand and Loess Soils**: June 1st – August 31st (all farms).
+- **Clay and Peat Soils**: June 1st – August 31st (only for farms with a derogation permit).
 
 ### 2. Grassland Destruction (Gras-naar-Bouwland)
 
@@ -152,7 +149,7 @@ When grassland is replaced by Maize or specific Potato types, a reduction of **6
 
 The `fdm-calculator` automatically detects grassland renewal and destruction events by analyzing the sequence of cultivations. It verifies the soil type, location (NV-gebied), and farm derogation status to apply the correct reduction.
 
-If a renewal or destruction action is performed **outside** the legally allowed periods, the calculator will provide a descriptive error message to ensure compliance.
+If a renewal or destruction action is performed **outside** the legally allowed periods, the calculator does not apply the grassland reduction and does not raise an error.
 
 :::info Reductions are cumulative
 Article 28d applies alongside the grassland provisions, so a grassland reduction and a catch crop reduction can both apply to the same field and are added together. A field that was destroyed for maize without a catch crop the previous autumn therefore receives 65 + 20 = 85 kg N/ha. The `normSource` lists every reduction that was applied.

--- a/fdm-docs/docs/insights/fertilizer-application-norms/nl/2025/stikstofgebruiksnorm.md
+++ b/fdm-docs/docs/insights/fertilizer-application-norms/nl/2025/stikstofgebruiksnorm.md
@@ -43,7 +43,7 @@ A field marked as a buffer strip (`b_bufferstrip`) receives a norm of 0.
 
 - **Quinoa (`nl_1022`)**: Mapped to `Bladgewassen, Spinazie volgteelt` per official RVO gewascodes guidelines.
 - **Grass-like Catch Crops (`nl_6751`, `nl_6789`, `nl_6753`)**: Mapped to their respective grass-seed norm rows (`Akkerbouwgewassen, Graszaad, ...`) per RVO classification.
-- **Nature, green fallow and non-agricultural areas (`nl_332`, `nl_335`, `nl_6794`)**: Mapped to `Geen plaatsingsruimte` (0 kg N/ha).
+- **Nature, green fallow and non-agricultural areas (`nl_332`, `nl_335`, `nl_6794`)**: Mapped to `Geen plaatsingsruimte` (0 kg N/ha). Green fallow (`nl_6794`, _groene braak, spontane opkomst_) is assigned 0 kg N/ha standard placement space by default in FDM to prevent unwarranted standard nitrogen allocation to untilled/fallow land unless actively managed as a groenbemester.
 
 ---
 
@@ -54,9 +54,10 @@ The following statutory options and specialized exceptions from the _Uitvoerings
 1. **Yield-based norm increases (`Opbrengstafhankelijke verhoging` / `Stikstofdifferentiatie`, art. 28c Urm / Bijlage A Tabel 1a)**: Higher norms for sugar beets, potatoes, cereals, and vegetables based on 3-year verified historical yield records.
 2. **French-fry potatoes on clay (`Fritesaardappelen op klei`, Tabel 2a)**: Differentiated nitrogen norms requiring specific registration.
 3. **Grass seed with fodder cut (`Graszaad met voedersnede`)**: Combining grass seed norm with temporary grassland norm when a fodder cut is taken in spring/autumn.
-4. **Mixed crops / Undersowing (`Mengteelt / Onderzaai`)**: Differentiated calculation for intercropped arable plants.
-5. **Fixed farm-level nitrogen norm (`Vaste norm op bedrijfsniveau`, footnote 9)**: The 110 kg N/ha fixed allowance when the farm's weighted average is between 100 and 110 kg N/ha.
-6. **Two-year winter crop budget split (`Winterteelt "waarvan ten hoogste na 31/12"`, footnote 5/18)**: Multi-year budget cap attribution between sowing year and harvest year.
+4. **Grass seed stubble destruction (`Graszaadstoppel ter vernietiging in najaar of vroege voorjaar`, footnote 7b)**: Requires specialized management verification (e.g. min 8-10 weeks standing duration, ploughing after 1 Dec) not modeled in standard crop plans.
+5. **Mixed crops / Undersowing (`Mengteelt / Onderzaai`)**: Differentiated calculation for intercropped arable plants.
+6. **Fixed farm-level nitrogen norm (`Vaste norm op bedrijfsniveau`, footnote 9)**: The 110 kg N/ha fixed allowance when the farm's weighted average is between 100 and 110 kg N/ha.
+7. **Two-year winter crop budget split (`Winterteelt "waarvan ten hoogste na 31/12"`, footnote 5/18)**: Multi-year budget cap attribution between sowing year and harvest year.
 
 ---
 

--- a/fdm-docs/docs/insights/fertilizer-application-norms/nl/2026/stikstofgebruiksnorm.md
+++ b/fdm-docs/docs/insights/fertilizer-application-norms/nl/2026/stikstofgebruiksnorm.md
@@ -46,7 +46,7 @@ A field marked as a buffer strip (`b_bufferstrip`) receives a norm of 0.
 
 - **Quinoa (`nl_1022`)**: Mapped to `Bladgewassen, Spinazie volgteelt` per official RVO gewascodes guidelines.
 - **Grass-like Catch Crops (`nl_6751`, `nl_6789`, `nl_6753`)**: Mapped to their respective grass-seed norm rows (`Akkerbouwgewassen, Graszaad, ...`) per RVO classification.
-- **Nature, green fallow and non-agricultural areas (`nl_332`, `nl_335`, `nl_6794`)**: Mapped to `Geen plaatsingsruimte` (0 kg N/ha).
+- **Nature, green fallow and non-agricultural areas (`nl_332`, `nl_335`, `nl_6794`)**: Mapped to `Geen plaatsingsruimte` (0 kg N/ha). Green fallow (`nl_6794`, _groene braak, spontane opkomst_) is assigned 0 kg N/ha standard placement space by default in FDM to prevent unwarranted standard nitrogen allocation to untilled/fallow land unless actively managed as a groenbemester.
 
 ---
 
@@ -57,9 +57,10 @@ The following statutory options and specialized exceptions from the _Uitvoerings
 1. **Yield-based norm increases (`Opbrengstafhankelijke verhoging` / `Stikstofdifferentiatie`, art. 28c Urm / Bijlage A Tabel 1a)**: Higher norms for sugar beets, potatoes, cereals, and vegetables based on 3-year verified historical yield records.
 2. **French-fry potatoes on clay (`Fritesaardappelen op klei`, Tabel 2a)**: Differentiated nitrogen norms requiring specific registration.
 3. **Grass seed with fodder cut (`Graszaad met voedersnede`)**: Combining grass seed norm with temporary grassland norm when a fodder cut is taken in spring/autumn.
-4. **Mixed crops / Undersowing (`Mengteelt / Onderzaai`)**: Differentiated calculation for intercropped arable plants.
-5. **Fixed farm-level nitrogen norm (`Vaste norm op bedrijfsniveau`, footnote 9)**: The 110 kg N/ha fixed allowance when the farm's weighted average is between 100 and 110 kg N/ha.
-6. **Two-year winter crop budget split (`Winterteelt "waarvan ten hoogste na 31/12"`, footnote 5/18)**: Multi-year budget cap attribution between sowing year and harvest year.
+4. **Grass seed stubble destruction (`Graszaadstoppel ter vernietiging in najaar of vroege voorjaar`, footnote 7b)**: Requires specialized management verification (e.g. min 8-10 weeks standing duration, ploughing after 1 Dec) not modeled in standard crop plans.
+5. **Mixed crops / Undersowing (`Mengteelt / Onderzaai`)**: Differentiated calculation for intercropped arable plants.
+6. **Fixed farm-level nitrogen norm (`Vaste norm op bedrijfsniveau`, footnote 9)**: The 110 kg N/ha fixed allowance when the farm's weighted average is between 100 and 110 kg N/ha.
+7. **Two-year winter crop budget split (`Winterteelt "waarvan ten hoogste na 31/12"`, footnote 5/18)**: Multi-year budget cap attribution between sowing year and harvest year.
 
 ---
 

--- a/fdm-docs/docs/insights/fertilizer-application-norms/nl/2026/stikstofgebruiksnorm.md
+++ b/fdm-docs/docs/insights/fertilizer-application-norms/nl/2026/stikstofgebruiksnorm.md
@@ -145,12 +145,7 @@ Specific nitrogen usage norm reductions (`kortingen`) apply when grassland is re
 
 ### 1. Grassland Renewal (Gras-na-Gras)
 
-When grassland is directly followed by new grassland, a reduction of **50 kg N/ha** applies. This is only allowed within specific periods:
-
-- **Sand and Loess Soils**: June 1st – August 31st.
-- **Clay and Peat Soils**: February 1st – September 15th.
-
-Because derogation ended after 2025, the clay and peat period no longer varies by derogation status or `NV-gebied`.
+When grassland is directly followed by new grassland, a reduction of **50 kg N/ha** applies. Per footnote 14, this applies across all soil types when renewal occurs between **June 1st and August 31st**.
 
 ### 2. Grassland Destruction (Gras-naar-Bouwland)
 
@@ -170,7 +165,7 @@ The reduction is not applied when the preceding crop was itself a catch crop, si
 
 The `fdm-calculator` detects grassland renewal and destruction events by analysing the sequence of cultivations, then verifies the soil region and `NV-gebied` status to apply the correct reduction.
 
-If a renewal or destruction action is performed **outside** the legally allowed periods, the calculator raises a descriptive error rather than returning a norm.
+If a renewal or destruction action is performed **outside** the legally allowed periods, the calculator withholds the reduction (no korting applied) without raising an error.
 
 :::info Reductions are cumulative
 Article 28d applies alongside the grassland provisions, so a grassland reduction and a catch crop reduction can both apply to the same field and are added together. A field that was destroyed for maize without a catch crop the previous autumn therefore receives 65 + 20 = 85 kg N/ha. The `normSource` lists every reduction that was applied.

--- a/fdm-docs/docs/insights/fertilizer-application-norms/nl/2026/stikstofgebruiksnorm.md
+++ b/fdm-docs/docs/insights/fertilizer-application-norms/nl/2026/stikstofgebruiksnorm.md
@@ -15,24 +15,53 @@ Derogation ended after 2025, so the nitrogen norm no longer depends on a farm's 
 
 ### How the Norm Works
 
-The nitrogen usage norm sets the maximum total effective nitrogen (in kg N/ha) that can be applied to a field. The calculation follows a step-by-step process to find the most precise norm based on various factors.
+The nitrogen usage norm sets the maximum total effective nitrogen (in kg N/ha) that can be applied to a field in a calendar year. Per RVO Tabel 2, norms are determined **per hectare per teelt** and summed across all crops grown on a field in the calendar year.
 
 #### Calculation Steps
 
-1. **Identify Main Crop**: The main crop for 2026 is determined from your cultivation plan — the crop present longest between 15 May and 15 July. If no crop covers that window, the field is treated as green fallow (`Groene braak, spontane opkomst`).
+1. **Identify Main Crop (`hoofdteelt`)**: The main crop for 2026 is determined from your cultivation plan — the crop present longest between **15 May and 15 July**. If no crop covers that window, the field falls back to green fallow (`Groene braak, spontane opkomst`).
 2. **Determine Geographical Context**: The field's location is used to check:
-   - If it is in a **Nutrient-Polluted Area (`NV-gebied`)**, which results in a stricter (lower) norm.
+   - If it is in a **Nutrient-Polluted Area (`NV-gebied`)**, which results in a stricter (20% lower) norm.
    - The dominant **soil region** (`zand_nwc`, `zand_zuid`, `klei`, `veen`, or `loess`).
-3. **Find the Standard Norm**: The main crop is looked up in the official RVO Table 2 (or the NV-gebied variant).
+3. **Calculate Per-Crop Norms**: For each crop grown in the norm year:
+   - **First Crop (`1e teelt`)**: The hoofdteelt receives the primary standard norm from RVO Tabel 2.
+   - **Successive Crops (`Volgteelt`)**: Any crop following the main crop receives its volgteelt norm where defined in Tabel 2 (e.g. spinach, lettuce varieties, endive, meadow grass, red fescue, tall fescue).
+   - **Green Manures (`Groenbemesters`)**: Non-leguminous catch crops receive the groenbemester norm (60/50/50/50/60 kg N/ha) if statutory conditions of footnote 7a are met (sown before 1 September following cereals, rapeseed, or grass seed; not destroyed before 1 February of the next year; or 50% on sand/loess after temporary grassland).
+   - **Exclusion after Maize**: Per footnotes 2 and 6, no additional norm is granted for green manures, catch crops, or temporary grassland following maize.
 4. **Apply Specific Rules**: The standard norm is refined with additional rules for certain crops:
    - **Grassland (`Grasland`)**: The norm depends on whether the grassland is grazed (`beweiden`) or fully mown (`volledig maaien`).
    - **Temporary Grassland (`Tijdelijk grasland`)**: The norm is adjusted based on the cultivation period.
    - **Potatoes (`Aardappelen`)**: The norm is adjusted based on the potato variety.
    - **Outdoor Flowers (`Buitenbloemen`)**: A higher norm is applied for specific varieties.
-5. **Select the Final Norm**: The final value is selected based on the field's soil region and `NV-gebied` status.
-6. **Apply Nitrogen Usage Norm Reductions (`Kortingen`)**: The norm is reduced if catch crop or winter crop requirements were not met in the **previous** year on sand and loess soils, and/or if grassland was renewed or destroyed. Reductions are **cumulative**: they are added together rather than applied as alternatives. If the result would be negative, it is set to 0.
+5. **Sum Cultivation Norms**: The total field nitrogen allowance is the sum of norms across all cultivations in the year.
+6. **Apply Nitrogen Usage Norm Reductions (`Kortingen`)**: Reductions are subtracted from the total:
+   - **Catch crop reduction (art. 28d Urm)**: Assessed on the previous calendar year (2025) on sand and loess.
+   - **Grassland renewal (gras-na-gras, footnote 14)**: 50 kg N/ha reduction when grassland is renewed between **1 June and 31 August** across all soil types.
+   - **Grassland destruction (gras-naar-bouwland, footnotes 15/16)**: 65 kg N/ha reduction when destroyed for maize or eligible consumption/factory potatoes within allowed spring windows (excluding previous catch-crop grass).
+   - Reductions are **cumulative**. If the total norm would become negative, it is floored at 0.
 
 A field marked as a buffer strip (`b_bufferstrip`) receives a norm of 0.
+
+### Intentional Crop Code Mappings
+
+- **Quinoa (`nl_1022`)**: Mapped to `Bladgewassen, Spinazie volgteelt` per official RVO gewascodes guidelines.
+- **Grass-like Catch Crops (`nl_6751`, `nl_6789`, `nl_6753`)**: Mapped to their respective grass-seed norm rows (`Akkerbouwgewassen, Graszaad, ...`) per RVO classification.
+- **Nature, green fallow and non-agricultural areas (`nl_332`, `nl_335`, `nl_6794`)**: Mapped to `Geen plaatsingsruimte` (0 kg N/ha).
+
+---
+
+## Provisions Not (Yet) Implemented
+
+The following statutory options and specialized exceptions from the _Uitvoeringsregeling Meststoffenwet_ are currently out of scope:
+
+1. **Yield-based norm increases (`Opbrengstafhankelijke verhoging` / `Stikstofdifferentiatie`, art. 28c Urm / Bijlage A Tabel 1a)**: Higher norms for sugar beets, potatoes, cereals, and vegetables based on 3-year verified historical yield records.
+2. **French-fry potatoes on clay (`Fritesaardappelen op klei`, Tabel 2a)**: Differentiated nitrogen norms requiring specific registration.
+3. **Grass seed with fodder cut (`Graszaad met voedersnede`)**: Combining grass seed norm with temporary grassland norm when a fodder cut is taken in spring/autumn.
+4. **Mixed crops / Undersowing (`Mengteelt / Onderzaai`)**: Differentiated calculation for intercropped arable plants.
+5. **Fixed farm-level nitrogen norm (`Vaste norm op bedrijfsniveau`, footnote 9)**: The 110 kg N/ha fixed allowance when the farm's weighted average is between 100 and 110 kg N/ha.
+6. **Two-year winter crop budget split (`Winterteelt "waarvan ten hoogste na 31/12"`, footnote 5/18)**: Multi-year budget cap attribution between sowing year and harvest year.
+
+---
 
 ### How the FDM Calculator Determines the Norm
 
@@ -60,11 +89,11 @@ The reduction applied to the 2026 norm is caused by what happened in autumn 2025
 
 No reduction applies if a designated **winter crop (`winterteelt`)** covered the ground instead of a catch crop. Winter crops fall into three groups, and the group determines which crop the calculator examines:
 
-| Group | Examples | Which crop is checked |
-| :---- | :------- | :-------------------- |
-| Listed as **both** a catch crop and a winter crop | winter wheat, winter barley, rye, grasses and grass-seed crops | The **main crop of the norm year** (sown in autumn of the previous year, harvested in the norm year) |
-| Winter crop only, late-harvested or perennial | sugar and fodder beet lifted on or after 1 November, Brussels sprouts, chicory, asparagus, top fruit, grassland | The **main crop of the previous year** |
-| Winter crop only, autumn-sown | spinach sown after 1 August, kohlrabi and pak choi planted after 1 August | The crop grown **after** the previous year's main crop |
+| Group                                             | Examples                                                                                                        | Which crop is checked                                                                                |
+| :------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
+| Listed as **both** a catch crop and a winter crop | winter wheat, winter barley, rye, grasses and grass-seed crops                                                  | The **main crop of the norm year** (sown in autumn of the previous year, harvested in the norm year) |
+| Winter crop only, late-harvested or perennial     | sugar and fodder beet lifted on or after 1 November, Brussels sprouts, chicory, asparagus, top fruit, grassland | The **main crop of the previous year**                                                               |
+| Winter crop only, autumn-sown                     | spinach sown after 1 August, kohlrabi and pak choi planted after 1 August                                       | The crop grown **after** the previous year's main crop                                               |
 
 For crops in the first group, the exception only applies if the crop is **not destroyed before 16 May** of the norm year — which is what makes it the main crop of that year rather than a catch crop.
 


### PR DESCRIPTION
Closes #754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Nitrogen usage norms now accumulate across multiple crops within a calendar year, including main and follow-up crops.
  - Added clearer calculation sources, crop-specific explanations, reductions, and supported crop-code handling.
  - Fertilizer application amounts now show appropriate units and display values when available.
  - Added a collapsible disclaimer for unsupported norm scenarios.

- **Bug Fixes**
  - Corrected 2025 and 2026 norm values, crop mappings, labels, and calculation rules.
  - Improved handling of grassland, maize, green manure, derogation, and invalid date scenarios.

- **Documentation**
  - Updated 2025 and 2026 nitrogen norm guidance with calculation rules, reductions, exclusions, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->