### PR TITLE
Use current year for farm overview calendar links

### DIFF
--- a/.changeset/tame-plums-flow.md
+++ b/.changeset/tame-plums-flow.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-app": patch
+---
+
+Fix the farm overview linking to the latest available calendar year (which can be in the future) instead of the current year when opening Atlas, elevation or soil map, which could show new users an empty year with no fields yet.

--- a/.changeset/tame-plums-flow.md
+++ b/.changeset/tame-plums-flow.md
@@ -1,5 +1,0 @@
----
-"@nmi-agro/fdm-app": patch
----
-
-Fix the farm overview linking to the latest available calendar year (which can be in the future) instead of the current year when opening Atlas, elevation or soil map, which could show new users an empty year with no fields yet.

--- a/fdm-app/CHANGELOG.md
+++ b/fdm-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog fdm-app
 
+## 0.35.3
+
+### Patch Changes
+
+- [#770](https://github.com/nmi-agro/fdm/pull/770) [`288e0b1`](https://github.com/nmi-agro/fdm/commit/288e0b1c1ad9144f7aa5bf2a0ba54f2bad1bfa92) Thanks [@SvenVw](https://github.com/SvenVw)! - Fix the farm overview linking to the latest available calendar year (which can be in the future) instead of the current year when opening Atlas, elevation or soil map, which could show new users an empty year with no fields yet.
+
 ## 0.35.2
 
 ### Patch Changes

--- a/fdm-app/app/routes/farm._index.tsx
+++ b/fdm-app/app/routes/farm._index.tsx
@@ -40,7 +40,7 @@ import { extractFormValuesFromRequest } from "~/lib/form"
 import { getTimeBasedGreeting } from "~/lib/greetings"
 import { parseOrganizationMetadata } from "~/lib/organization-helpers"
 import { AccessFormSchema } from "~/lib/schemas/access.schema"
-import { useCalendarStore } from "../store/calendar"
+import { useCalendarStore } from "~/store/calendar"
 
 // Meta
 export const meta: MetaFunction = () => {
@@ -548,7 +548,7 @@ export default function AppIndex() {
                   />
                 </NavLink>
                 <NavLink
-                                    to={`/farm/${atlasBaseFarmId}/${calendar}/atlas/soil`}
+                  to={`/farm/${atlasBaseFarmId}/${calendar}/atlas/soil`}
                   className="group hover:bg-muted/50 flex items-center gap-3 p-4 transition-colors"
                 >
                   <div

--- a/fdm-app/app/routes/farm._index.tsx
+++ b/fdm-app/app/routes/farm._index.tsx
@@ -33,7 +33,6 @@ import {
 import { Separator } from "~/components/ui/separator"
 import { SidebarInset } from "~/components/ui/sidebar"
 import { auth, getSession } from "~/lib/auth.server"
-import { getCalendarSelection } from "~/lib/calendar"
 import { clientConfig } from "~/lib/config"
 import { handleLoaderError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
@@ -41,6 +40,7 @@ import { extractFormValuesFromRequest } from "~/lib/form"
 import { getTimeBasedGreeting } from "~/lib/greetings"
 import { parseOrganizationMetadata } from "~/lib/organization-helpers"
 import { AccessFormSchema } from "~/lib/schemas/access.schema"
+import { useCalendarStore } from "../store/calendar"
 
 // Meta
 export const meta: MetaFunction = () => {
@@ -69,9 +69,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
   try {
     // Get the session
     const session = await getSession(request)
-
-    // Get latest available year
-    const calendar = getCalendarSelection()[0] ?? "all"
 
     // Get a list of possible farms of the user
     const farms = await getFarms(fdm, session.principal_id)
@@ -168,7 +165,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
       }),
       farmOptions: farmOptions,
       organizations: organizations,
-      calendar: calendar,
       username: session.userName,
       pendingInvitations: pendingInvitations,
       pendingOrganizationInvitations: pendingOrganizationInvitations,
@@ -260,6 +256,7 @@ function SupportNote() {
 export default function AppIndex() {
   const loaderData = useLoaderData<typeof loader>()
   const greeting = getTimeBasedGreeting()
+  const calendar = useCalendarStore((state) => state.calendar)
 
   const [userFarms, organizationFarms] = useMemo(() => {
     const userFarms = loaderData.farms
@@ -382,7 +379,7 @@ export default function AppIndex() {
 
                 <Card className="group hover:border-primary/50 relative flex flex-col overflow-hidden border transition-all hover:shadow-md">
                   <NavLink
-                    to={`/farm/${atlasBaseFarmId}/${loaderData.calendar}/atlas/fields`}
+                    to={`/farm/${atlasBaseFarmId}/${calendar}/atlas/fields`}
                     className="flex h-full flex-col"
                   >
                     <CardHeader className="pb-4">
@@ -509,7 +506,7 @@ export default function AppIndex() {
             <div className="px-4 pb-6 md:px-8 md:pb-8">
               <div className="divide-y overflow-hidden rounded-lg border">
                 <NavLink
-                  to={`/farm/${atlasBaseFarmId}/${loaderData.calendar}/atlas/fields`}
+                  to={`/farm/${atlasBaseFarmId}/${calendar}/atlas/fields`}
                   className="group hover:bg-muted/50 flex items-center gap-3 p-4 transition-colors"
                 >
                   <div
@@ -530,7 +527,7 @@ export default function AppIndex() {
                   />
                 </NavLink>
                 <NavLink
-                  to={`/farm/${atlasBaseFarmId}/${loaderData.calendar}/atlas/elevation`}
+                  to={`/farm/${atlasBaseFarmId}/${calendar}/atlas/elevation`}
                   className="group hover:bg-muted/50 flex items-center gap-3 p-4 transition-colors"
                 >
                   <div
@@ -551,7 +548,7 @@ export default function AppIndex() {
                   />
                 </NavLink>
                 <NavLink
-                  to={`/farm/${atlasBaseFarmId}/${loaderData.calendar}/atlas/soil`}
+                                    to={`/farm/${atlasBaseFarmId}/${calendar}/atlas/soil`}
                   className="group hover:bg-muted/50 flex items-center gap-3 p-4 transition-colors"
                 >
                   <div

--- a/fdm-app/package.json
+++ b/fdm-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nmi-agro/fdm-app",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "private": true,
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Farm overview links now use the latest selected calendar year when opening Atlas, elevation, and soil maps.
* **Chores**
  * Updated the app version to 0.35.3.
  * Added release details to the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #767 