### PR TITLE
Exclude and hide buffer strip and nature fields from BLN3 indicators, measures, and API calculations

### DIFF
--- a/fdm-app/app/components/blocks/indicators/atlas.tsx
+++ b/fdm-app/app/components/blocks/indicators/atlas.tsx
@@ -214,7 +214,9 @@ export default function IndicatorsMap({
           {label && (
             <div className="mt-1.5 flex items-center justify-between gap-3 border-t pt-1.5">
               <span className="text-muted-foreground truncate">{label}</span>
-              {hoverScore != null ? (
+              {hoverInfo.properties.isExcluded ? (
+                <span className="text-muted-foreground italic">Bufferstrook/natuur</span>
+              ) : hoverScore != null ? (
                 <span
                   className="inline-flex shrink-0 items-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold text-white"
                   style={{
@@ -230,7 +232,9 @@ export default function IndicatorsMap({
           )}
           {!label && (
             <p className="text-muted-foreground mt-0.5">
-              {hoverScore != null ? (
+              {hoverInfo.properties.isExcluded ? (
+                "Bufferstrook/natuurperceel (uitgesloten)"
+              ) : hoverScore != null ? (
                 <>
                   Score:{" "}
                   <span

--- a/fdm-app/app/components/blocks/indicators/table.tsx
+++ b/fdm-app/app/components/blocks/indicators/table.tsx
@@ -16,6 +16,7 @@ import { HeatmapCell } from "./table-cell"
 type FieldRow = {
   b_id: string
   b_name: string | null | undefined
+  isNature: boolean
   scores: Record<string, { score01: number; index01: number } | undefined>
   /** Number of indicators with display score <40 for this field */
   knelpuntCount: number
@@ -36,7 +37,7 @@ const CATEGORY_BORDER: Record<Ecosysteemdienst, string> = {
 }
 
 type HeatmapTableProps = {
-  fields: { b_id: string; b_name: string | null | undefined }[]
+  fields: { b_id: string; b_name: string | null | undefined; isNature?: boolean }[]
   fieldScores: FieldBln3Score[]
   activeCategories: Ecosysteemdienst[]
   showIndex: boolean
@@ -100,6 +101,7 @@ export function HeatmapTable({
       return {
         b_id: field.b_id,
         b_name: field.b_name,
+        isNature: field.isNature ?? false,
         scores,
         knelpuntCount,
       }
@@ -113,16 +115,34 @@ export function HeatmapTable({
       accessorKey: "b_name",
       header: "Perceel",
       cell: ({ row }) => (
-        <NavLink
-          to={
-            basePathFormatter
-              ? basePathFormatter(row.original.b_id)
-              : `${basePath}/${row.original.b_id}`
-          }
-          className="font-medium hover:underline"
-        >
-          {row.original.b_name ?? row.original.b_id}
-        </NavLink>
+        <div className="flex items-center gap-1.5">
+          <NavLink
+            to={
+              basePathFormatter
+                ? basePathFormatter(row.original.b_id)
+                : `${basePath}/${row.original.b_id}`
+            }
+            className="truncate font-medium hover:underline"
+          >
+            {row.original.b_name ?? row.original.b_id}
+          </NavLink>
+          {row.original.isNature ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="bg-muted text-muted-foreground inline-flex shrink-0 items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium">
+                  Natuur
+                </span>
+              </TooltipTrigger>
+              <TooltipContent
+                side="right"
+                className="bg-popover text-popover-foreground max-w-[220px] border text-xs shadow-md"
+              >
+                Natuurperceel — BLN3 berekent geen bodemkwaliteitsindicatoren voor dit
+                perceel.
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
+        </div>
       ),
     }
 

--- a/fdm-app/app/components/blocks/measures/field-summary-table.tsx
+++ b/fdm-app/app/components/blocks/measures/field-summary-table.tsx
@@ -2,7 +2,9 @@
  * Table of per-field measure summaries on the farm measures overview page.
  *
  * Features:
- *  - Fuzzy search + buffer-strip toggle (shared via useFieldFilterStore)
+ *  - Fuzzy search (shared via useFieldFilterStore)
+ *  - Buffer strips and "nature" fields are always hidden (not user-toggleable):
+ *    soil management measures never apply to them.
  *  - Row selection with "Maatregel toevoegen" action button
  *  - Sortable columns (field name, cultivation, area, measure count)
  */
@@ -20,7 +22,6 @@ import fuzzysort from "fuzzysort"
 import { Plus } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useParams } from "react-router"
-import { FieldFilterToggle } from "~/components/custom/field-filter-toggle"
 import { Button } from "~/components/ui/button"
 import { Input } from "~/components/ui/input"
 import {
@@ -54,7 +55,6 @@ export function FieldSummaryTable({
 
   const { b_id_farm } = useParams()
   const syncFarm = useFieldFilterStore((s) => s.syncFarm)
-  const showProductiveOnly = useFieldFilterStore((s) => s.showProductiveOnly)
   const searchTerms = useFieldFilterStore((s) => s.searchTerms)
   const setSearchTerms = useFieldFilterStore((s) => s.setSearchTerms)
 
@@ -65,11 +65,12 @@ export function FieldSummaryTable({
   }, [b_id_farm, syncFarm])
 
   const filteredData = useMemo(() => {
-    let rows = data
-
-    if (showProductiveOnly) {
-      rows = rows.filter((r) => !r.b_bufferstrip)
-    }
+    // Buffer strips and "nature" fields (hoofdteelt b_lu_croprotation === "nature")
+    // are never relevant for soil management measures — always hide them here,
+    // regardless of the shared productive-only filter used on other pages.
+    let rows = data.filter(
+      (r) => !r.b_bufferstrip && r.mainCultivations?.[0]?.b_lu_croprotation !== "nature",
+    )
 
     if (searchTerms.trim()) {
       rows = rows.filter((r) => {
@@ -85,7 +86,7 @@ export function FieldSummaryTable({
     }
 
     return rows
-  }, [data, searchTerms, showProductiveOnly])
+  }, [data, searchTerms])
 
   const table = useReactTable({
     data: filteredData,
@@ -118,7 +119,6 @@ export function FieldSummaryTable({
           className="w-full max-w-sm sm:w-auto sm:flex-grow"
         />
         <div className="ml-auto flex items-center gap-2">
-          <FieldFilterToggle />
           {canModify && (
             <TooltipProvider>
               <Tooltip>
@@ -184,9 +184,7 @@ export function FieldSummaryTable({
                   colSpan={columns.length}
                   className="text-muted-foreground h-20 text-center text-sm"
                 >
-                  {searchTerms || showProductiveOnly
-                    ? "Geen percelen gevonden."
-                    : "Geen percelen beschikbaar."}
+                  {searchTerms ? "Geen percelen gevonden." : "Geen percelen beschikbaar."}
                 </TableCell>
               </TableRow>
             )}

--- a/fdm-app/app/integrations/bln3.server.ts
+++ b/fdm-app/app/integrations/bln3.server.ts
@@ -19,13 +19,16 @@ import {
   getBln3Score,
 } from "@nmi-agro/fdm-calculator"
 import {
+  type Cultivation,
   type Field,
+  getCultivationsForFarm,
   getFields,
   getMeasures,
   type PrincipalId,
   type Timeframe,
 } from "@nmi-agro/fdm-core"
 import type { FieldMeasure } from "~/lib/indicators"
+import { getMainCultivation } from "~/lib/hoofdteelt.server"
 import { getNmiApiKey } from "~/integrations/nmi.server"
 import { fdm } from "~/lib/fdm.server"
 
@@ -41,6 +44,12 @@ export type FieldBln3Score = {
   b_id: string
   score: Bln3Score | null
   error: string | null
+  /**
+   * `true` when the field is a buffer strip or a "nature" plot (hoofdteelt
+   * `b_lu_croprotation === "nature"`) and was excluded from the BLN3
+   * calculation without ever calling `getIndicatorsForField`/the NMI API.
+   */
+  isExcluded?: boolean
 }
 
 export type FieldBln3Result = {
@@ -51,6 +60,65 @@ export type FieldBln3Result = {
 export type MeasureApplicabilityInfo = {
   applicability: Bln3MeasureApplicabilityStatus
   message: string
+}
+
+/**
+ * Determines whether a field is a buffer strip or a "nature" plot (hoofdteelt
+ * `b_lu_croprotation === "nature"` for the given calendar year) and should
+ * therefore be excluded from BLN3 indicator/measure calculations entirely.
+ *
+ * Pure/sync — takes the field's already-loaded cultivations so it can be
+ * reused for many fields at once without an extra fetch per field.
+ */
+function isFieldExcludedFromBln3(
+  field: Pick<Field, "b_id" | "b_bufferstrip">,
+  cultivations: Cultivation[],
+  calendarYear: string,
+): boolean {
+  if (field.b_bufferstrip) {
+    return true
+  }
+  const mainCultivation = getMainCultivation(cultivations, calendarYear)
+  return mainCultivation?.b_lu_croprotation === "nature"
+}
+
+/**
+ * Determines, for every field in a farm, whether it is a buffer strip or a
+ * "nature" plot and should therefore be excluded from BLN3 calculations.
+ *
+ * Uses a single `getCultivationsForFarm` query for the whole farm (instead of
+ * one `getCultivations` call per field) to avoid N+1 queries when checking
+ * many fields at once.
+ */
+export async function getFieldsExcludedFromBln3ForFarm({
+  principal_id,
+  b_id_farm,
+  fields,
+  calendarYear,
+  cultivationsByField,
+}: {
+  principal_id: PrincipalId
+  b_id_farm: string
+  fields: Pick<Field, "b_id" | "b_bufferstrip">[]
+  calendarYear: string
+  /**
+   * Optional pre-fetched cultivations map (e.g. one the caller already loaded
+   * via `getCultivationsForFarm` for other purposes) to avoid an extra
+   * farm-wide query.
+   */
+  cultivationsByField?: Map<string, Cultivation[]>
+}): Promise<Set<string>> {
+  const cultivationsMap =
+    cultivationsByField ?? (await getCultivationsForFarm(fdm, principal_id, b_id_farm))
+
+  const excludedFieldIds = new Set<string>()
+  for (const field of fields) {
+    const cultivations = cultivationsMap.get(field.b_id) ?? []
+    if (isFieldExcludedFromBln3(field, cultivations, calendarYear)) {
+      excludedFieldIds.add(field.b_id)
+    }
+  }
+  return excludedFieldIds
 }
 
 /**
@@ -82,6 +150,8 @@ export async function getIndicatorsForField({
  *
  * Uses `Promise.allSettled` so individual field failures do not abort the
  * whole farm load. Fields that fail return `null` with an error message.
+ * Buffer strip / "nature" fields are skipped entirely (no
+ * `getIndicatorsForField` call, no NMI API call) and flagged `isExcluded`.
  */
 export async function getIndicatorsForFarm({
   principal_id,
@@ -95,21 +165,34 @@ export async function getIndicatorsForFarm({
   preloadedFields?: Field[]
 }): Promise<FieldBln3Score[]> {
   const fields = preloadedFields ?? (await getFields(fdm, principal_id, b_id_farm, timeframe))
+  const calendarYear = String(timeframe?.end?.getFullYear() ?? new Date().getFullYear())
+
+  const excludedFieldIds = await getFieldsExcludedFromBln3ForFarm({
+    principal_id,
+    b_id_farm,
+    fields,
+    calendarYear,
+  })
 
   const results = await Promise.allSettled(
     fields.map((field) =>
-      getIndicatorsForField({
-        principal_id,
-        b_id: field.b_id,
-        timeframe,
-      }),
+      excludedFieldIds.has(field.b_id)
+        ? Promise.resolve(null)
+        : getIndicatorsForField({
+            principal_id,
+            b_id: field.b_id,
+            timeframe,
+          }),
     ),
   )
 
   return results.map((result, index) => {
     const b_id = fields[index].b_id
+    if (excludedFieldIds.has(b_id)) {
+      return { b_id, score: null, error: null, isExcluded: true }
+    }
     if (result.status === "fulfilled") {
-      return { b_id, score: result.value.score, error: null }
+      return { b_id, score: result.value?.score ?? null, error: null }
     }
     const errorMessage =
       result.reason instanceof Error ? result.reason.message : String(result.reason)
@@ -203,21 +286,41 @@ async function mapInBatches<T, R>(
  * Uses `Promise.allSettled` in batches of 5 so individual field failures return an empty record
  * for that field rather than failing the entire request or overwhelming external services.
  *
+ * Buffer strip / "nature" fields are filtered out before batching (using a single
+ * farm-wide cultivations query, not one per field) so no NMI calls are dispatched for them.
+ *
  * @returns A record mapping `b_id` to a record mapping `m_id` to `MeasureApplicabilityInfo`.
  */
 export async function getMeasureApplicabilityForFields({
   principal_id,
-  b_ids,
+  b_id_farm,
+  fields,
   b_year,
   timeframe,
+  cultivationsByField,
 }: {
   principal_id: PrincipalId
-  b_ids: string[]
+  b_id_farm: string
+  fields: Pick<Field, "b_id" | "b_bufferstrip">[]
   b_year: number
   timeframe?: Timeframe
+  /** Optional pre-fetched cultivations map to avoid an extra farm-wide query. */
+  cultivationsByField?: Map<string, Cultivation[]>
 }): Promise<Record<string, Record<string, MeasureApplicabilityInfo>>> {
+  const calendarYear = String(b_year)
+  const excludedFieldIds = await getFieldsExcludedFromBln3ForFarm({
+    principal_id,
+    b_id_farm,
+    fields,
+    calendarYear,
+    cultivationsByField,
+  })
+  const applicableFieldIds = fields
+    .map((f) => f.b_id)
+    .filter((b_id) => !excludedFieldIds.has(b_id))
+
   const BATCH_SIZE = 5
-  const results = await mapInBatches(b_ids, BATCH_SIZE, (b_id) =>
+  const results = await mapInBatches(applicableFieldIds, BATCH_SIZE, (b_id) =>
     getMeasureApplicabilityForField({
       principal_id,
       b_id,
@@ -228,8 +331,13 @@ export async function getMeasureApplicabilityForFields({
 
   const fieldApplicabilityMap: Record<string, Record<string, MeasureApplicabilityInfo>> = {}
 
+  // Excluded fields (buffer strips / nature plots) never get NMI applicability calls.
+  for (const field of fields) {
+    fieldApplicabilityMap[field.b_id] = {}
+  }
+
   results.forEach((result, index) => {
-    const b_id = b_ids[index]
+    const b_id = applicableFieldIds[index]
     if (result.status === "fulfilled") {
       fieldApplicabilityMap[b_id] = result.value
     } else {

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.indicators.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.indicators.tsx
@@ -98,6 +98,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
             b_name: field.b_name ?? null,
             b_area: field.b_area ?? null,
             avgScore: computeFieldAvgScore(fs),
+            isExcluded: fs?.isExcluded ?? false,
             ...aggProps,
             ...indicatorProps,
           },

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.indicators.$b_id.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.indicators.$b_id.tsx
@@ -11,6 +11,7 @@ import { getCultivationCatalogue } from "@nmi-agro/fdm-data"
 import { simplify } from "@turf/simplify"
 import { format } from "date-fns"
 import { nl } from "date-fns/locale"
+import { Info } from "lucide-react"
 import { lazy, Suspense, useEffect, useMemo, useState } from "react"
 import {
   data,
@@ -28,6 +29,7 @@ import { FieldInputDialog } from "~/components/blocks/indicators/field-input-dia
 import { IndicatorCard } from "~/components/blocks/indicators/indicator-card"
 import { MeasuresToggle } from "~/components/blocks/indicators/measures-toggle"
 import { getCultivationColor } from "~/components/custom/cultivation-colors"
+import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert"
 import { Badge } from "~/components/ui/badge"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card"
 import {
@@ -364,6 +366,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     return {
       field,
       fieldScore,
+      isExcluded: bln3Inputs.excluded === true,
       fieldMeasures,
       fieldsGeoJSON,
       selectedFieldGeoJSON,
@@ -426,6 +429,7 @@ export default function IndicatorsFieldDetail() {
   const {
     field,
     fieldScore,
+    isExcluded,
     fieldMeasures,
     fieldsGeoJSON,
     selectedFieldGeoJSON,
@@ -539,6 +543,19 @@ export default function IndicatorsFieldDetail() {
         }
         rightNode={<Bln3BetaBanner />}
       />
+
+      <div className="px-4 pt-4 sm:px-6 lg:px-8">
+        {isExcluded && (
+          <Alert className="mb-4">
+            <Info className="h-4 w-4" />
+            <AlertTitle>Bufferstrook of natuurperceel</AlertTitle>
+            <AlertDescription>
+              Dit perceel is een bufferstrook of natuurperceel en is uitgesloten van de BLN3
+              bodemkwaliteitsindicatoren.
+            </AlertDescription>
+          </Alert>
+        )}
+      </div>
 
       <div className="px-4 pb-16 sm:px-6 lg:px-8">
         <div className="flex flex-col gap-6 lg:flex-row">

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.indicators._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.indicators._index.tsx
@@ -1,4 +1,4 @@
-import { getFields } from "@nmi-agro/fdm-core"
+import { getFields, getCultivations } from "@nmi-agro/fdm-core"
 import { Map } from "lucide-react"
 import { useEffect, useMemo, useState, useTransition } from "react"
 import {
@@ -28,10 +28,11 @@ import { useAnalytics } from "~/hooks/use-analytics"
 import { getIndicatorsForFarm } from "~/integrations/bln3.server"
 import { type AggregationId, computeAreaWeightedAggregation } from "~/lib/aggregations"
 import { getSession } from "~/lib/auth.server"
-import { getTimeframe } from "~/lib/calendar"
+import { getCalendar, getTimeframe } from "~/lib/calendar"
 import { clientConfig } from "~/lib/config"
 import { handleLoaderError, reportError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
+import { getMainCultivation } from "~/lib/hoofdteelt.server"
 import { type Ecosysteemdienst, INDICATORS } from "~/lib/indicators"
 import { cn } from "~/lib/utils"
 
@@ -59,6 +60,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     const session = await getSession(request)
     const timeframe = getTimeframe(params)
+    const calendar = getCalendar(params)
 
     const fields = await getFields(fdm, session.principal_id, b_id_farm, timeframe)
 
@@ -75,13 +77,21 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       }
     }
 
+    const cultivationsByField = await Promise.all(
+      fields.map((f) => getCultivations(fdm, session.principal_id, f.b_id)),
+    )
+
     return {
-      fields: fields.map((f) => ({
-        b_id: f.b_id,
-        b_name: f.b_name,
-        b_bufferstrip: f.b_bufferstrip ?? false,
-        b_area: f.b_area ?? null,
-      })),
+      fields: fields.map((f, index) => {
+        const mainCultivation = getMainCultivation(cultivationsByField[index], calendar)
+        return {
+          b_id: f.b_id,
+          b_name: f.b_name,
+          b_bufferstrip: f.b_bufferstrip ?? false,
+          b_lu_croprotation: mainCultivation?.b_lu_croprotation ?? null,
+          b_area: f.b_area ?? null,
+        }
+      }),
       fieldScores,
     }
   } catch (error) {
@@ -139,7 +149,9 @@ export default function IndicatorsFarmIndex() {
     startTransition(() => setHideBufferstrips(!checked))
   }
 
-  // Filter fields based on bufferstrip toggle and search text
+  // Filter fields based on the bufferstrip toggle and search text.
+  // Nature fields are always shown here (BLN3 doesn't calculate scores for them,
+  // but they aren't hidden by this toggle — only buffer strips are).
   const filteredFields = useMemo(() => {
     let result = hideBufferstrips ? fields.filter((f) => !f.b_bufferstrip) : fields
     if (fieldSearch) {
@@ -282,6 +294,7 @@ export default function IndicatorsFarmIndex() {
                 fields={filteredFields.map((field) => ({
                   b_id: field.b_id,
                   b_name: field.b_name,
+                  isNature: field.b_lu_croprotation === "nature",
                 }))}
                 fieldScores={filteredScores}
                 activeCategories={activeCategories}

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.measures._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.measures._index.tsx
@@ -3,7 +3,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import {
   addMeasure,
   checkPermission,
-  getCultivations,
+  getCultivationsForFarm,
   getFarm,
   getFields,
   getMeasuresForFarm,
@@ -52,7 +52,10 @@ import { Field, FieldGroup, FieldLabel } from "~/components/ui/field"
 import { Label } from "~/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "~/components/ui/radio-group"
 import { Separator } from "~/components/ui/separator"
-import { getMeasureApplicabilityForFields } from "~/integrations/bln3.server"
+import {
+  getFieldsExcludedFromBln3ForFarm,
+  getMeasureApplicabilityForFields,
+} from "~/integrations/bln3.server"
 import { getMapStyle } from "~/integrations/map"
 import { getSession } from "~/lib/auth.server"
 import { getCalendar, getTimeframe } from "~/lib/calendar"
@@ -105,19 +108,34 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     ])
 
     const calendarYear = Number(calendar)
-    const fieldIds = fields.map((f) => f.b_id)
+    const resolvedCalendarYear = Number.isFinite(calendarYear)
+      ? calendarYear
+      : new Date().getFullYear()
 
-    const [applicabilityByField, fieldCultivations] = await Promise.all([
+    // Single farm-wide cultivations query, reused for main-cultivation lookups,
+    // BLN3 measure applicability, and BLN3 exclusion checks below (avoids N+1
+    // `getCultivations` calls per field).
+    const cultivationsByField = await getCultivationsForFarm(fdm, session.principal_id, b_id_farm)
+
+    const [applicabilityByField, excludedFieldIds] = await Promise.all([
       getMeasureApplicabilityForFields({
         principal_id: session.principal_id,
-        b_ids: fieldIds,
-        b_year: Number.isFinite(calendarYear) ? calendarYear : new Date().getFullYear(),
+        b_id_farm,
+        fields,
+        b_year: resolvedCalendarYear,
         timeframe,
+        cultivationsByField,
       }).catch(() => ({})),
-      Promise.all(fields.map((f) => getCultivations(fdm, session.principal_id, f.b_id))),
+      getFieldsExcludedFromBln3ForFarm({
+        principal_id: session.principal_id,
+        b_id_farm,
+        fields,
+        calendarYear: String(resolvedCalendarYear),
+        cultivationsByField,
+      }),
     ])
-    const fieldList = fields.map((f, i) => {
-      const cultivations = fieldCultivations[i]
+    const fieldList = fields.map((f) => {
+      const cultivations = cultivationsByField.get(f.b_id) ?? []
       const main = getMainCultivation(cultivations, calendar) ?? null
       return {
         b_id: f.b_id,
@@ -186,18 +204,22 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       a.m_name.localeCompare(b.m_name, "nl"),
     )
 
-    // Compute summary stats from measuresMap (no extra API calls needed)
-    const totalMeasures = [...measuresMap.values()].reduce(
-      (sum, measures) => sum + measures.length,
+    // Compute summary stats over applicable (non-excluded) fields only — buffer
+    // strips and nature fields never get soil management measures.
+    const applicableFields = fields.filter((f) => !excludedFieldIds.has(f.b_id))
+    const totalMeasures = applicableFields.reduce(
+      (sum, f) => sum + (measuresMap.get(f.b_id)?.length ?? 0),
       0,
     )
-    const fieldsWithMeasures = [...measuresMap.values()].filter((m) => m.length > 0).length
-    const fieldsWithoutMeasures = fields.length - fieldsWithMeasures
+    const fieldsWithMeasures = applicableFields.filter(
+      (f) => (measuresMap.get(f.b_id)?.length ?? 0) > 0,
+    ).length
+    const fieldsWithoutMeasures = applicableFields.length - fieldsWithMeasures
 
     // Per-field summary for the table — derived from existing data
-    const fieldSummaries = fields.map((f, i) => {
+    const fieldSummaries = fields.map((f) => {
       const fieldMeasures = measuresMap.get(f.b_id) ?? []
-      const cultivation = fieldCultivations[i]
+      const cultivation = cultivationsByField.get(f.b_id) ?? []
       const main = getMainCultivation(cultivation, calendar) ?? null
       return {
         b_id: f.b_id,
@@ -230,7 +252,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       fieldSummaries,
       applicabilityByField,
       stats: {
-        totalFields: fields.length,
+        totalFields: applicableFields.length,
         totalMeasures,
         fieldsWithMeasures,
         fieldsWithoutMeasures,

--- a/fdm-calculator/src/bln3/applicability.test.ts
+++ b/fdm-calculator/src/bln3/applicability.test.ts
@@ -235,3 +235,26 @@ describe("getBln3MeasureApplicability function export", () => {
     expect(typeof getBln3MeasureApplicability).toBe("function")
   })
 })
+
+describe("getBln3MeasureApplicability exclusion short-circuit", () => {
+  const mockFdm = {} as any
+
+  beforeAll(() => {
+    vi.stubGlobal("fetch", vi.fn())
+  })
+
+  afterEach(() => {
+    vi.mocked(fetch).mockClear()
+  })
+
+  afterAll(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("should return { applicability: [] } without calling fetch when inputs are excluded (buffer strip / nature field)", async () => {
+    const result = await getBln3MeasureApplicability(mockFdm, { ...baseInputs, excluded: true })
+
+    expect(result).toEqual<Bln3MeasureApplicabilityResult>({ applicability: [] })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+})

--- a/fdm-calculator/src/bln3/applicability.ts
+++ b/fdm-calculator/src/bln3/applicability.ts
@@ -1,3 +1,4 @@
+import type { FdmType } from "@nmi-agro/fdm-core"
 import { withCalculationCache } from "@nmi-agro/fdm-core"
 import type {
   Bln3MeasureApplicabilityInputs,
@@ -104,9 +105,27 @@ export async function requestBln3MeasureApplicability(
  * redacted). Bumping `calculatorVersion` in `package.ts` invalidates all
  * existing cache entries.
  */
-export const getBln3MeasureApplicability = withCalculationCache(
+const cachedRequestBln3MeasureApplicability = withCalculationCache(
   requestBln3MeasureApplicability,
   "requestBln3MeasureApplicability",
   pkg.calculatorVersion,
   ["nmiApiKey"],
 )
+
+/**
+ * Calculates (or retrieves the cached) BLN3 measure applicability for a field.
+ *
+ * Buffer strips and "nature" plots (`inputs.excluded === true`, as flagged by
+ * `collectInputForBln3MeasureApplicability`) are not relevant for BLN3 soil
+ * management measures: this short-circuits to `{ applicability: [] }`
+ * without calling the NMI API or the calculation cache.
+ */
+export async function getBln3MeasureApplicability(
+  fdm: FdmType,
+  inputs: Bln3MeasureApplicabilityInputs,
+): Promise<Bln3MeasureApplicabilityResult> {
+  if (inputs.excluded) {
+    return { applicability: [] }
+  }
+  return cachedRequestBln3MeasureApplicability(fdm, inputs)
+}

--- a/fdm-calculator/src/bln3/index.test.ts
+++ b/fdm-calculator/src/bln3/index.test.ts
@@ -247,6 +247,29 @@ describe("getBln3Score cache semantics", () => {
   })
 })
 
+describe("getBln3Score exclusion short-circuit", () => {
+  const mockFdm = {} as any
+
+  beforeAll(() => {
+    vi.stubGlobal("fetch", vi.fn())
+  })
+
+  afterEach(() => {
+    vi.mocked(fetch).mockClear()
+  })
+
+  afterAll(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("should return null without calling fetch when inputs are excluded (buffer strip / nature field)", async () => {
+    const result = await getBln3Score(mockFdm, { ...baseInputs, excluded: true })
+
+    expect(result).toBeNull()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+})
+
 // getBln3Score is the cached wrapper around requestBln3Score via withCalculationCache.
 // Cache behaviour is tested thoroughly in fdm-core/src/calculator.test.ts.
 // We just verify the export exists and has the correct shape.

--- a/fdm-calculator/src/bln3/index.ts
+++ b/fdm-calculator/src/bln3/index.ts
@@ -1,3 +1,4 @@
+import type { FdmType } from "@nmi-agro/fdm-core"
 import { withCalculationCache } from "@nmi-agro/fdm-core"
 import type { Bln3Score, Bln3ScoreInputs, Bln3ScoreResponse } from "./types"
 import pkg from "../package"
@@ -82,9 +83,27 @@ export async function requestBln3Score(inputs: Bln3ScoreInputs): Promise<Bln3Sco
  * redacted). Bumping `calculatorVersion` in `package.ts` invalidates all
  * existing cache entries.
  */
-export const getBln3Score = withCalculationCache(
+const cachedRequestBln3Score = withCalculationCache(
   requestBln3Score,
   "requestBln3Score",
   pkg.calculatorVersion,
   ["nmiApiKey"],
 )
+
+/**
+ * Calculates (or retrieves the cached) BLN3 score for a field.
+ *
+ * Buffer strips and "nature" plots (`inputs.excluded === true`, as flagged by
+ * `collectInputForBln3Score`) are not relevant for BLN3 soil quality scoring:
+ * this short-circuits to `null` without calling the NMI API or the
+ * calculation cache.
+ */
+export async function getBln3Score(
+  fdm: FdmType,
+  inputs: Bln3ScoreInputs,
+): Promise<Bln3Score | null> {
+  if (inputs.excluded) {
+    return null
+  }
+  return cachedRequestBln3Score(fdm, inputs)
+}

--- a/fdm-calculator/src/bln3/input.test.ts
+++ b/fdm-calculator/src/bln3/input.test.ts
@@ -526,6 +526,53 @@ describe("collectInputForBln3Score", () => {
     expect(result).not.toHaveProperty("a_sc_bcs")
     expect(result).not.toHaveProperty("a_ew_bcs")
   })
+
+  it("should exclude buffer strip fields without mapping soil/cultivation/measure data", async () => {
+    const bufferstripField: Field = { ...mockField, b_bufferstrip: true }
+    mockedGetField.mockResolvedValue(bufferstripField)
+    mockedGetSoilAnalyses.mockResolvedValue([mockSoilAnalysis])
+    mockedGetCultivations.mockResolvedValue([mockCultivation])
+    mockedGetMeasures.mockResolvedValue([mockMeasure])
+
+    const result = await collectInputForBln3Score(mockFdm, principal_id, b_id, timeframe)
+
+    expect(result).toEqual({ excluded: true, a_lat: 51.6, a_lon: 5.2 })
+    expect(result).not.toHaveProperty("cultivations")
+    expect(result).not.toHaveProperty("measures")
+    expect(result).not.toHaveProperty("b_soiltype_agr")
+  })
+
+  it("should exclude 'nature' fields (hoofdteelt b_lu_croprotation === 'nature')", async () => {
+    const natureCultivation: Cultivation = {
+      ...mockCultivation,
+      b_lu_catalogue: "nl_999",
+      b_lu_croprotation: "nature",
+      b_lu_start: new Date("2024-05-01"),
+      b_lu_end: new Date("2024-08-01"),
+    }
+    mockedGetField.mockResolvedValue(mockField)
+    mockedGetSoilAnalyses.mockResolvedValue([mockSoilAnalysis])
+    mockedGetCultivations.mockResolvedValue([natureCultivation])
+    mockedGetMeasures.mockResolvedValue([mockMeasure])
+
+    const result = await collectInputForBln3Score(mockFdm, principal_id, b_id, timeframe)
+
+    expect(result).toEqual({ excluded: true, a_lat: 51.6, a_lon: 5.2 })
+    expect(result).not.toHaveProperty("cultivations")
+    expect(result).not.toHaveProperty("measures")
+  })
+
+  it("should NOT exclude a regular agricultural field", async () => {
+    mockedGetField.mockResolvedValue(mockField)
+    mockedGetSoilAnalyses.mockResolvedValue([mockSoilAnalysis])
+    mockedGetCultivations.mockResolvedValue([mockCultivation])
+    mockedGetMeasures.mockResolvedValue([mockMeasure])
+
+    const result = await collectInputForBln3Score(mockFdm, principal_id, b_id, timeframe)
+
+    expect(result.excluded).toBeUndefined()
+    expect(result).toHaveProperty("cultivations")
+  })
 })
 
 import { findHoofdteelt } from "../shared/hoofdteelt"
@@ -598,6 +645,69 @@ describe("collectInputForBln3MeasureApplicability", () => {
     await expect(
       collectInputForBln3MeasureApplicability(mockFdm, principal_id, b_id, 2026),
     ).rejects.toThrow(`Failed to collect BLN3 measure applicability inputs for field ${b_id}`)
+  })
+
+  it("should exclude buffer strip fields without mapping soil/cultivation data", async () => {
+    const bufferstripField: Field = { ...mockField, b_bufferstrip: true }
+    mockedGetField.mockResolvedValue(bufferstripField)
+    mockedGetSoilAnalyses.mockResolvedValue([mockSoilAnalysis])
+    mockedGetCultivations.mockResolvedValue([mockCultivation])
+    mockedGetFertilizerApplications.mockResolvedValue([])
+
+    const result = await collectInputForBln3MeasureApplicability(
+      mockFdm,
+      principal_id,
+      b_id,
+      2024,
+      timeframe,
+    )
+
+    expect(result).toEqual({ excluded: true, a_lat: 51.6, a_lon: 5.2, b_year: 2024 })
+    expect(result).not.toHaveProperty("cultivations")
+    expect(result).not.toHaveProperty("b_soiltype_agr")
+  })
+
+  it("should exclude 'nature' fields (hoofdteelt b_lu_croprotation === 'nature') for the given b_year", async () => {
+    const natureCultivation: Cultivation = {
+      ...mockCultivation,
+      b_lu_catalogue: "nl_999",
+      b_lu_croprotation: "nature",
+      b_lu_start: new Date("2024-05-01"),
+      b_lu_end: new Date("2024-08-01"),
+    }
+    mockedGetField.mockResolvedValue(mockField)
+    mockedGetSoilAnalyses.mockResolvedValue([mockSoilAnalysis])
+    mockedGetCultivations.mockResolvedValue([natureCultivation])
+    mockedGetFertilizerApplications.mockResolvedValue([])
+
+    const result = await collectInputForBln3MeasureApplicability(
+      mockFdm,
+      principal_id,
+      b_id,
+      2024,
+      timeframe,
+    )
+
+    expect(result).toEqual({ excluded: true, a_lat: 51.6, a_lon: 5.2, b_year: 2024 })
+    expect(result).not.toHaveProperty("cultivations")
+  })
+
+  it("should NOT exclude a regular agricultural field", async () => {
+    mockedGetField.mockResolvedValue(mockField)
+    mockedGetSoilAnalyses.mockResolvedValue([mockSoilAnalysis])
+    mockedGetCultivations.mockResolvedValue([mockCultivation])
+    mockedGetFertilizerApplications.mockResolvedValue([])
+
+    const result = await collectInputForBln3MeasureApplicability(
+      mockFdm,
+      principal_id,
+      b_id,
+      2024,
+      timeframe,
+    )
+
+    expect(result.excluded).toBeUndefined()
+    expect(result).toHaveProperty("cultivations")
   })
 })
 

--- a/fdm-calculator/src/bln3/input.ts
+++ b/fdm-calculator/src/bln3/input.ts
@@ -15,6 +15,41 @@ import type {
 import { findHoofdteelt } from "../shared/hoofdteelt"
 
 /**
+ * Minimal field shape required to check BLN3 exclusion.
+ */
+type FieldForBln3Exclusion = Pick<fdmSchema.fieldsTypeSelect, "b_bufferstrip">
+
+/**
+ * Determines whether a field should be excluded from BLN3 score / measure
+ * applicability calculations: buffer strips (`b_bufferstrip === true`) and
+ * "nature" plots (hoofdteelt `b_lu_croprotation === "nature"` for the given
+ * year) are not relevant for soil quality measures/indicators.
+ *
+ * @param field - The field to check (only `b_bufferstrip` is used).
+ * @param cultivations - The field's cultivation history, used to resolve the
+ *   hoofdteelt (main cultivation) for `year`.
+ * @param year - The calendar year to resolve the hoofdteelt for.
+ * @returns `true` if the field is a buffer strip or a nature plot.
+ */
+function isFieldExcludedFromBln3(
+  field: FieldForBln3Exclusion,
+  cultivations: Awaited<ReturnType<typeof getCultivations>>,
+  year: number,
+): boolean {
+  if (field.b_bufferstrip) {
+    return true
+  }
+
+  const hoofdteeltCatalogue = findHoofdteelt(cultivations, year, true)
+  if (hoofdteeltCatalogue === null) {
+    return false
+  }
+
+  const hoofdteelt = cultivations.find((c) => c.b_lu_catalogue === hoofdteeltCatalogue)
+  return hoofdteelt?.b_lu_croprotation === "nature"
+}
+
+/**
  * Collects all field data needed for a BLN3 score calculation from the FDM database.
  *
  * Fetches field geometry (lat/lon), the most recent soil analysis, cultivations, and
@@ -48,6 +83,14 @@ export async function collectInputForBln3Score(
 
     // b_centroid = [lon, lat] (ST_X = longitude, ST_Y = latitude)
     const [a_lon, a_lat] = field.b_centroid
+
+    // Buffer strips and "nature" plots (hoofdteelt b_lu_croprotation === "nature")
+    // are excluded from BLN3 calculations. Short-circuit before doing the more
+    // expensive soil analysis / measure mapping work.
+    const exclusionYear = timeframe?.end?.getFullYear() ?? new Date().getFullYear()
+    if (isFieldExcludedFromBln3(field, cultivations, exclusionYear)) {
+      return { excluded: true, a_lat, a_lon }
+    }
 
     // For each numeric field, pick the most recent soil analysis record that has
     // a non-null value for that field. Lab and BCS analyses are stored as separate
@@ -194,6 +237,11 @@ export async function collectInputForBln3MeasureApplicability(
     ])
 
     const [a_lon, a_lat] = field.b_centroid
+
+    // Buffer strips and "nature" plots are excluded from BLN3 calculations.
+    if (isFieldExcludedFromBln3(field, cultivations, b_year)) {
+      return { excluded: true, a_lat, a_lon, b_year }
+    }
 
     const labNumericFields = [
       "a_ca_co_po",

--- a/fdm-calculator/src/bln3/types.d.ts
+++ b/fdm-calculator/src/bln3/types.d.ts
@@ -28,6 +28,14 @@ export type Bln3Measure = {
  * fields are optional and improve calculation quality when provided.
  */
 export type Bln3ScoreCollectedInputs = {
+  /**
+   * When `true`, the field is a buffer strip (`b_bufferstrip`) or a "nature" plot
+   * (hoofdteelt `b_lu_croprotation === "nature"`) and is excluded from BLN3
+   * calculations. All other fields are omitted/irrelevant in that case, and
+   * `getBln3Score` must short-circuit to `null` without calling the NMI API.
+   */
+  excluded?: boolean
+
   // ── Location (required) ──────────────────────────────────────────────────
   /** Latitude of the field centroid (WGS84; EPSG:4326) */
   a_lat: number
@@ -195,6 +203,14 @@ export type Bln3MeasureApplicabilityItem = {
  * Note: `measures` is intentionally NOT sent.
  */
 export type Bln3MeasureApplicabilityCollectedInputs = {
+  /**
+   * When `true`, the field is a buffer strip (`b_bufferstrip`) or a "nature" plot
+   * (hoofdteelt `b_lu_croprotation === "nature"`) and is excluded from BLN3
+   * calculations. `getBln3MeasureApplicability` must short-circuit to
+   * `{ applicability: [] }` without calling the NMI API.
+   */
+  excluded?: boolean
+
   // ── Required ─────────────────────────────────────────────────────────────
   /** Latitude of the field centroid (WGS84; EPSG:4326) */
   a_lat: number


### PR DESCRIPTION
**Enhancements**

- No requests to the BLN3 API is done for buffer strips anymore.
- Now the userclearly sees that the reason for there being no BLN3 data is that the field is a buffer strip or nature, instead of a generic no data message.