### PR TITLE
Do not include unknown layers in the getHoveredFeatures query

### DIFF
--- a/.changeset/full-chicken-help.md
+++ b/.changeset/full-chicken-help.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-app": patch
+---
+
+When no farm is selected (so the fieldsSaved layer is missing) gewaspercelen atlas no longer throws errors and the field tooltip/popup works.

--- a/.changeset/full-chicken-help.md
+++ b/.changeset/full-chicken-help.md
@@ -1,5 +1,0 @@
----
-"@nmi-agro/fdm-app": patch
----
-
-When no farm is selected (so the fieldsSaved layer is missing) gewaspercelen atlas no longer throws errors and the field tooltip/popup works.

--- a/fdm-app/CHANGELOG.md
+++ b/fdm-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog fdm-app
 
+## 0.36.3
+
+### Patch Changes
+
+- [#788](https://github.com/nmi-agro/fdm/pull/788) [`ef2afe0`](https://github.com/nmi-agro/fdm/commit/ef2afe0806d8bb0f69000bb0854852f7fbf5e9b1) Thanks [@BoraIneviNMI](https://github.com/BoraIneviNMI)! - When no farm is selected (so the fieldsSaved layer is missing) gewaspercelen atlas no longer throws errors and the field tooltip/popup works.
+
 ## 0.36.2
 
 ### Patch Changes

--- a/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
@@ -54,28 +54,11 @@ export function FieldTooltip({
   clickRedirectsToDetailsPage?: boolean
   touchDisplaysPopupInstead?: boolean
 }) {
-  const { current: map } = useMap()
-  const [zoom, setZoom] = useState<number | null>(map ? map.getZoom() : null)
-
-  useEffect(() => {
-    if (!map) return
-    const onZoom = () => setZoom(map.getZoom())
-    onZoom()
-    map.on("zoom", onZoom)
-    return () => {
-      map.off("zoom", onZoom)
-    }
-  }, [map])
-
   const layers = useMemo(() => (Array.isArray(layer) ? layer : [layer]), [layer])
   const layersExclude = useMemo(
     () => (!layerExclude ? [] : Array.isArray(layerExclude) ? layerExclude : [layerExclude]),
     [layerExclude],
   )
-
-  if (!map || zoom === null || zoom < zoomLevelFields) {
-    return null
-  }
 
   return (
     <AtlasTooltip
@@ -83,6 +66,7 @@ export function FieldTooltip({
       layersExclude={layersExclude}
       onFeatureClicked={onFeatureClicked}
       touchDisplaysPopupInstead={touchDisplaysPopupInstead}
+      zoomLevelFields={zoomLevelFields}
       render={(props) => {
         const { features, mode } = props
 

--- a/fdm-app/app/components/blocks/atlas/atlas-tooltip.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-tooltip.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/app/lib/utils"
 import { Button } from "~/components/ui/button"
 import { Card, CardHeader, CardContent, CardFooter } from "~/components/ui/card"
 import { useMapContainer } from "./atlas-shell"
-import { useStableSet, ZOOM_LEVEL_FIELDS } from "./atlas-util"
+import { useStableSet } from "./atlas-util"
 
 type AtlasTooltipRenderProps = {
   features: MapGeoJSONFeature[]
@@ -38,7 +38,7 @@ export function AtlasTooltip({
   layers,
   layersExclude,
   onFeatureClicked,
-  zoomLevelFields = ZOOM_LEVEL_FIELDS,
+  zoomLevelFields,
   touchDisplaysPopupInstead = true,
 }: {
   render: (props: AtlasTooltipRenderProps) => ReactNode
@@ -69,7 +69,7 @@ export function AtlasTooltip({
       const coords = new Point(x, y)
 
       const zoom = map.getZoom()
-      if (zoom < zoomLevelFields) return []
+      if (typeof zoomLevelFields === "number" && zoom < zoomLevelFields) return []
       if (!map.isStyleLoaded()) return []
 
       const renderedIncludedLayers = [...layersSet].filter((layerId) => map.getLayer(layerId))

--- a/fdm-app/app/components/blocks/atlas/atlas-tooltip.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-tooltip.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/app/lib/utils"
 import { Button } from "~/components/ui/button"
 import { Card, CardHeader, CardContent, CardFooter } from "~/components/ui/card"
 import { useMapContainer } from "./atlas-shell"
-import { useStableSet } from "./atlas-util"
+import { useStableSet, ZOOM_LEVEL_FIELDS } from "./atlas-util"
 
 type AtlasTooltipRenderProps = {
   features: MapGeoJSONFeature[]
@@ -38,12 +38,14 @@ export function AtlasTooltip({
   layers,
   layersExclude,
   onFeatureClicked,
+  zoomLevelFields = ZOOM_LEVEL_FIELDS,
   touchDisplaysPopupInstead = true,
 }: {
   render: (props: AtlasTooltipRenderProps) => ReactNode
   layers: string[]
   layersExclude?: string[]
   onFeatureClicked?: (feature: MapGeoJSONFeature) => void
+  zoomLevelFields?: number
   touchDisplaysPopupInstead?: boolean
 }) {
   const { current: map } = useMap()
@@ -66,9 +68,13 @@ export function AtlasTooltip({
     (map: MapRef, x: number, y: number) => {
       const coords = new Point(x, y)
 
+      const zoom = map.getZoom()
+      if (zoom < zoomLevelFields) return []
+      if (!map.getStyle()) return []
+
       if (layersExcludeSet.size > 0) {
         const excludedFeatures = map.queryRenderedFeatures(coords, {
-          layers: [...layersExcludeSet],
+          layers: [...layersExcludeSet].filter((layerId) => map.getLayer(layerId)),
         })
 
         if (excludedFeatures.length > 0) {
@@ -77,12 +83,12 @@ export function AtlasTooltip({
       }
 
       const features = map.queryRenderedFeatures(coords, {
-        layers: [...layersSet],
+        layers: [...layersSet].filter((layerId) => map.getLayer(layerId)),
       })
 
       return features
     },
-    [layersSet, layersExcludeSet],
+    [layersSet, layersExcludeSet, zoomLevelFields],
   )
 
   // Throttle tooltip updates to reduce flashing.

--- a/fdm-app/app/components/blocks/atlas/atlas-tooltip.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-tooltip.tsx
@@ -70,11 +70,21 @@ export function AtlasTooltip({
 
       const zoom = map.getZoom()
       if (zoom < zoomLevelFields) return []
-      if (!map.getStyle()) return []
+      if (!map.isStyleLoaded()) return []
 
-      if (layersExcludeSet.size > 0) {
+      const renderedIncludedLayers = [...layersSet].filter((layerId) => map.getLayer(layerId))
+
+      if (renderedIncludedLayers.length === 0) {
+        return []
+      }
+
+      const renderedExcludedLayers = [...layersExcludeSet].filter((layerId) =>
+        map.getLayer(layerId),
+      )
+
+      if (renderedExcludedLayers.length > 0) {
         const excludedFeatures = map.queryRenderedFeatures(coords, {
-          layers: [...layersExcludeSet].filter((layerId) => map.getLayer(layerId)),
+          layers: renderedExcludedLayers,
         })
 
         if (excludedFeatures.length > 0) {
@@ -82,11 +92,9 @@ export function AtlasTooltip({
         }
       }
 
-      const features = map.queryRenderedFeatures(coords, {
-        layers: [...layersSet].filter((layerId) => map.getLayer(layerId)),
+      return map.queryRenderedFeatures(coords, {
+        layers: renderedIncludedLayers,
       })
-
-      return features
     },
     [layersSet, layersExcludeSet, zoomLevelFields],
   )

--- a/fdm-app/package.json
+++ b/fdm-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nmi-agro/fdm-app",
-  "version": "0.36.2",
+  "version": "0.36.3",
   "private": true,
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
**Bug fixes**

- When no farm is selected (so the fieldsSaved) layer is missing gewaspercelen atlas no longer throws errors and the tooltip/popup works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the gewaspercelen atlas could error when no farm was selected.
  - Field tooltips and popups now work correctly when the relevant field layer is unavailable.
  - Improved tooltip behavior based on map zoom and layer availability.

- **Chores**
  - Released version 0.36.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->