### PR TITLE
Add zoom level warnings to all atlas pages

### DIFF
--- a/.changeset/vast-pans-fall.md
+++ b/.changeset/vast-pans-fall.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-app": minor
+---
+
+Now the user sees a zoom warning on all full-page atlases, not only on the field creation and elevation atlases.

--- a/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
@@ -25,6 +25,7 @@ import {
   AtlasTooltipFooter,
   AtlasTooltipHeader,
 } from "./atlas-tooltip"
+import { ZOOM_LEVEL_FIELDS } from "./atlas-util"
 
 /**
  * Renders a tooltip or popup showing the field name or the cultivation name and the corresponding area,
@@ -166,7 +167,13 @@ export function FieldTooltip({
   )
 }
 
-export function FieldsPanelZoom({ zoomLevelFields }: { zoomLevelFields: number }) {
+export function FieldsPanelZoomWarning({
+  zoomLevelFields = ZOOM_LEVEL_FIELDS,
+  canSelectFields = false,
+}: {
+  zoomLevelFields?: number
+  canSelectFields?: boolean
+}) {
   const { current: map } = useMap()
   const [panel, setPanel] = useState<React.ReactNode | null>(null)
 
@@ -178,9 +185,13 @@ export function FieldsPanelZoom({ zoomLevelFields }: { zoomLevelFields: number }
         if (zoom && zoom <= zoomLevelFields) {
           setPanel(
             <Alert>
-              <Info className="h-4 w-4" />
-              <AlertTitle>Let op!</AlertTitle>
-              <AlertDescription>Zoom in om percelen te kunnen selecteren.</AlertDescription>
+              <Info className="text-muted-foreground h-4 w-4" />
+              <AlertTitle className="text-muted-foreground">Let op!</AlertTitle>
+              <AlertDescription className="text-muted-foreground">
+                {canSelectFields
+                  ? "Zoom in om percelen te kunnen selecteren."
+                  : "Zoom in om percelen te kunnen zien."}
+              </AlertDescription>
             </Alert>,
           )
         } else {
@@ -202,7 +213,7 @@ export function FieldsPanelZoom({ zoomLevelFields }: { zoomLevelFields: number }
         map.off("zoom", throttledUpdatePanel)
       }
     }
-  }, [map, zoomLevelFields])
+  }, [map, zoomLevelFields, canSelectFields])
 
   return panel
 }

--- a/fdm-app/app/components/blocks/indicators/atlas.tsx
+++ b/fdm-app/app/components/blocks/indicators/atlas.tsx
@@ -15,6 +15,7 @@ import { Link, useNavigate } from "react-router"
 import { MapTilerAttribution } from "~/components/blocks/atlas/atlas-attribution"
 import { Controls } from "~/components/blocks/atlas/atlas-controls"
 import { ScoreLegend } from "~/components/blocks/atlas/atlas-legend"
+import { FieldsPanelZoomWarning } from "~/components/blocks/atlas/atlas-panels"
 import { Atlas } from "~/components/blocks/atlas/atlas-shell"
 import { FieldsSourceNotClickable } from "~/components/blocks/atlas/atlas-sources"
 import {
@@ -213,6 +214,7 @@ export default function IndicatorsMap({
       {/* Legend overlay — pointer-events-none so it doesn't block field clicks */}
       <div className="absolute bottom-6 left-2 z-10">
         <ScoreLegend label={label} />
+        {fieldsGeoJSON.features.length > 0 && <FieldsPanelZoomWarning />}
       </div>
     </div>
   )

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.fields._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.fields._index.tsx
@@ -8,7 +8,7 @@ import { Layer, type LayerProps } from "react-map-gl/maplibre"
 import { type LoaderFunctionArgs, useLoaderData, useNavigate, useParams } from "react-router"
 import { MapTilerAttribution } from "~/components/blocks/atlas/atlas-attribution"
 import { Controls } from "~/components/blocks/atlas/atlas-controls"
-import { FieldTooltip } from "~/components/blocks/atlas/atlas-panels"
+import { FieldsPanelZoomWarning, FieldTooltip } from "~/components/blocks/atlas/atlas-panels"
 import { Atlas } from "~/components/blocks/atlas/atlas-shell"
 import {
   FieldsSourceAvailable,
@@ -190,6 +190,11 @@ export default function FarmAtlasFieldsBlock() {
           void navigate(featureCentroidCoordinates)
         }}
       />
+      {fields && fields.features.length > 0 && (
+        <div className="fields-panel">
+          <FieldsPanelZoomWarning />
+        </div>
+      )}
     </Atlas>
   )
 }

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.soil-analysis._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.soil-analysis._index.tsx
@@ -15,6 +15,7 @@ import { type LoaderFunctionArgs, useLoaderData, useNavigate } from "react-route
 import { MapTilerAttribution } from "~/components/blocks/atlas/atlas-attribution"
 import { Controls } from "~/components/blocks/atlas/atlas-controls"
 import { SoilAnalysisLegend } from "~/components/blocks/atlas/atlas-legend"
+import { FieldsPanelZoomWarning } from "~/components/blocks/atlas/atlas-panels"
 import { Atlas } from "~/components/blocks/atlas/atlas-shell"
 import {
   getShadedSoilParameters,
@@ -319,31 +320,34 @@ export default function FarmAtlasFieldSoilAnalysisBlock() {
         />
       </Atlas>
       {/* Soil Parameter Dropdown */}
-      <Card className="absolute top-3 left-3 z-10 w-52 shadow-md">
-        <CardContent className="p-2">
-          <Select
-            value={selectedParameter}
-            onValueChange={(val) => setSelectedParameter(val as ShadedSoilParameters)}
-          >
-            <SelectTrigger className="h-8 w-full text-xs">
-              {parameterDescription?.name}
-            </SelectTrigger>
-            {/* var(--radix-select-content-available-height) is the recommended max-height here, however we have fallbacks in case that variable is missing. */}
-            <SelectContent className="max-h-[min(var(--radix-select-content-available-height,100vh),calc(var(--radix-select-trigger-height,0)+100*var(--spacing)))]">
-              {soilParameterOptions.map((opt) => {
-                return (
-                  <SelectItem key={opt.parameter} value={opt.parameter}>
-                    <div>
-                      <div className="font-medium">{opt.name}</div>
-                      <div className="text-muted-foreground text-xs">{opt.description}</div>
-                    </div>
-                  </SelectItem>
-                )
-              })}
-            </SelectContent>
-          </Select>
-        </CardContent>
-      </Card>
+      <div className="absolute top-3 left-3 z-10 max-w-52 space-y-3">
+        <Card className=" shadow-md">
+          <CardContent className="p-2">
+            <Select
+              value={selectedParameter}
+              onValueChange={(val) => setSelectedParameter(val as ShadedSoilParameters)}
+            >
+              <SelectTrigger className="h-8 w-full text-xs">
+                {parameterDescription?.name}
+              </SelectTrigger>
+              {/* var(--radix-select-content-available-height) is the recommended max-height here, however we have fallbacks in case that variable is missing. */}
+              <SelectContent className="max-h-[min(var(--radix-select-content-available-height,100vh),calc(var(--radix-select-trigger-height,0)+100*var(--spacing)))]">
+                {soilParameterOptions.map((opt) => {
+                  return (
+                    <SelectItem key={opt.parameter} value={opt.parameter}>
+                      <div>
+                        <div className="font-medium">{opt.name}</div>
+                        <div className="text-muted-foreground text-xs">{opt.description}</div>
+                      </div>
+                    </SelectItem>
+                  )
+                })}
+              </SelectContent>
+            </Select>
+          </CardContent>
+        </Card>
+        {fieldsData && fieldsData.features.length > 0 && <FieldsPanelZoomWarning />}
+      </div>
       {/* Soil Analysis Color Legend */}
       <div className="pointer-none absolute bottom-9 left-4">
         <SoilAnalysisLegend

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.soil.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.soil.tsx
@@ -10,7 +10,7 @@ import { Layer, type MapRef, Source } from "react-map-gl/maplibre"
 import { type LoaderFunctionArgs, type MetaFunction, useLoaderData, useParams } from "react-router"
 import { MapTilerAttribution } from "~/components/blocks/atlas/atlas-attribution"
 import { Controls } from "~/components/blocks/atlas/atlas-controls"
-import { FieldTooltip } from "~/components/blocks/atlas/atlas-panels"
+import { FieldsPanelZoomWarning, FieldTooltip } from "~/components/blocks/atlas/atlas-panels"
 import { Atlas } from "~/components/blocks/atlas/atlas-shell"
 import { SATELLITE_BACKGROUND_REQUIRED_MESSAGE } from "~/components/blocks/atlas/atlas-style-select"
 import { getFieldsStyle } from "~/components/blocks/atlas/atlas-styles"
@@ -474,6 +474,11 @@ export default function FarmAtlasSoilBlock() {
           layer={fieldsSavedId}
           touchDisplaysPopupInstead={false}
         />
+        {fields && fields.features.length > 0 && (
+          <div className="fields-panel">
+            <FieldsPanelZoomWarning />
+          </div>
+        )}
       </Atlas>
     </div>
   )

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.new._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.new._index.tsx
@@ -27,7 +27,7 @@ import { generateFeatureClass } from "~/components/blocks/atlas/atlas-functions"
 import {
   FieldTooltip,
   FieldsPanelSelection,
-  FieldsPanelZoom,
+  FieldsPanelZoomWarning,
 } from "~/components/blocks/atlas/atlas-panels"
 import { Atlas } from "~/components/blocks/atlas/atlas-shell"
 import {
@@ -337,7 +337,7 @@ export default function Index() {
                     numFieldsSaved={loaderData.fieldsSaved.features.length}
                     continueTo={loaderData.continueTo}
                   />
-                  <FieldsPanelZoom zoomLevelFields={ZOOM_LEVEL_FIELDS} />
+                  <FieldsPanelZoomWarning canSelectFields />
                 </div>
               </Atlas>
             )}

--- a/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.atlas.tsx
+++ b/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.atlas.tsx
@@ -26,7 +26,7 @@ import { generateFeatureClass } from "~/components/blocks/atlas/atlas-functions"
 import {
   FieldTooltip,
   FieldsPanelSelection,
-  FieldsPanelZoom,
+  FieldsPanelZoomWarning,
 } from "~/components/blocks/atlas/atlas-panels"
 import { Atlas } from "~/components/blocks/atlas/atlas-shell"
 import {
@@ -303,7 +303,7 @@ export default function Index() {
                     numFieldsSaved={loaderData.fieldsSaved.features.length}
                     continueTo={loaderData.continueTo}
                   />
-                  <FieldsPanelZoom zoomLevelFields={ZOOM_LEVEL_FIELDS} />
+                  <FieldsPanelZoomWarning canSelectFields />
                 </div>
               </Atlas>
             )}


### PR DESCRIPTION
**Enhancements**
The user now sees a zoom level warning on all relevant atlas pages.

Closes #790 